### PR TITLE
fix: Player getters getting called correctly for player scope changes

### DIFF
--- a/server/player/events.lua
+++ b/server/player/events.lua
@@ -12,7 +12,7 @@ AddEventHandler('playerEnteredScope', function(data)
     local player = Player(source)
 
     if player then
-        local inScope = player.get('inScope')
+        local inScope = player:get('inScope')
         inScope[target] = true
     end
 end)
@@ -23,7 +23,7 @@ AddEventHandler('playerLeftScope', function(data)
     local player = Player(source)
 
     if player then
-        local inScope = player.get('inScope')
+        local inScope = player:get('inScope')
         inScope[target] = nil
     end
 end)

--- a/server/player/main.lua
+++ b/server/player/main.lua
@@ -174,11 +174,12 @@ function CPlayer:logout()
         npwd:unloadPlayer(self.source)
     end
 
-    TriggerEvent('ox:playerLogout', player.source, player.userid, player.charid)
+    TriggerEvent('ox:playerLogout', self.source, self.userid, self.charid)
 
     self:save()
     self.charid = nil
     self.characters = selectCharacters(self.source, self.userid)
+    playerData[self.source] = nil
 
     TriggerClientEvent('ox:selectCharacter', self.source, self.characters)
 end
@@ -277,6 +278,7 @@ setmetatable(Player, {
         if player.charid then player:save() end
 
         TriggerEvent('ox:playerLogout', player.source, player.userid, player.charid)
+        playerData[player.source] = nil
         self.list[player.source] = nil
         self.count -= 1
     end,


### PR DESCRIPTION
* Found this issue with Entered and Left scope events where getting the inScope table was failing to self.source being nil
    * While investigating that issue, I also realized that playerData never got removed after a player logged out or left the server
        * While figuring out where to nil out playerData entries, I realized that the ox:playerLogout event trigger was attempting to get values from an incorrect object