### PR TITLE
chore(manifest): Bump server dependency version

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -14,7 +14,7 @@ repository   'https://github.com/overextended/ox_core'
 
 --[[ Manifest ]]--
 dependencies {
-	'/server:5895',
+	'/server:5904',
 	'/onesync',
 }
 


### PR DESCRIPTION
* With the usage of the CreateVehicleServerSetter native call a server version bump is required