### PR TITLE
fix(server/player): Wipe inScope table on logout

### DIFF
--- a/server/player/class.lua
+++ b/server/player/class.lua
@@ -203,6 +203,7 @@ function CPlayer:logout(dropped)
             steam = data.steam,
             fivem = data.fivem,
             discord = data.discord,
+            inScope = table.wipe(data.inScope),
         }
 
         TriggerClientEvent('ox:selectCharacter', self.source, self.characters)


### PR DESCRIPTION
On logout, a player was losing their inScope table. This update wipes the table but keeps it around