### PR TITLE
tweak(CVehicle): TaskEveryoneLeaveVehicle on entity

### DIFF
--- a/client/events.lua
+++ b/client/events.lua
@@ -12,14 +12,6 @@ AddStateBagChangeHandler('initVehicle', nil, function(bagName, key, value, reser
 
         if not entity then return end
 
-        for i = -1, 0 do
-            local ped = GetPedInVehicleSeat(entity, i)
-
-            if ped ~= cache.ped and ped > 0 and NetworkGetEntityOwner(ped) == cache.playerId then
-                DeleteEntity(ped)
-            end
-        end
-
         if NetworkGetEntityOwner(entity) == cache.playerId then
             lib.setVehicleProperties(entity, value[1])
             SetVehicleOnGroundProperly(entity)

--- a/server/vehicle/main.lua
+++ b/server/vehicle/main.lua
@@ -114,6 +114,9 @@ local function spawnVehicle(id, owner, group, plate, model, script, data, coords
             db.setStored(nil, self.id)
         end
 
+        -- Prevents population peds from spawning with the vehicle.
+        TaskEveryoneLeaveVehicle(entity)
+
         return self
     else
         print(("^1Failed to spawn vehicle '%s'^0"):format(model))


### PR DESCRIPTION
This server sided native prevents vehicles spawning with population peds. During 20 test cases with the native, no vehicle spawned with a ped inside, without the native peds spawned 75% of the time.