### PR TITLE
refactor(server/player): players instances are now created on connect…

### DIFF
--- a/server/player/class.lua
+++ b/server/player/class.lua
@@ -211,4 +211,16 @@ function CPlayer:logout(dropped)
     end
 end
 
+function CPlayer:setAsJoined(nonTempId)
+    self.source = nonTempId
+
+    local identifiers = GetPlayerIdentifiers(nonTempId)
+
+    self.init(identifiers)
+
+    local state = self.getState()
+    
+    state:set('userid', self.userid, true)
+end
+
 return CPlayer

--- a/server/player/main.lua
+++ b/server/player/main.lua
@@ -90,7 +90,7 @@ end
 ---Update the database with a player's current data.
 ---@param player CPlayer
 ---@param dropped boolean?
-function Player.save(player, dropped)
+function Player.save(player)
     if player.charid then
         db.updateCharacter(formatCharacterSaveData(player, os.date('%Y-%m-%d', os.time())--[[@as string]] ))
 
@@ -103,10 +103,6 @@ function Player.save(player, dropped)
                 group.remove(player, grade)
             end
         end
-    end
-
-    if dropped then
-        PlayerRegistry[player.source] = nil
     end
 end
 
@@ -132,13 +128,9 @@ local CPlayer = require 'player.class'
 ---Creates an instance of CPlayer.
 ---@param source number
 ---@return CPlayer
-function Player.new(source, identifiers)
-    local userid = db.getUserFromIdentifier(identifiers[Server.PRIMARY_IDENTIFIER])
-    local username = GetPlayerName(source)
+function Player.new(source, userid)
 
-    if not userid then
-        userid = db.createUser(username, identifiers) --[[@as number]]
-    end
+    local username = GetPlayerName(source)
 
     ---@type CPlayer
     local player = setmetatable({
@@ -146,15 +138,6 @@ function Player.new(source, identifiers)
         userid = userid,
         username = username,
     }, CPlayer)
-
-    player.init(identifiers)
-
-    local state = player.getState()
-    state:set('userid', player.userid, true)
-
-    for type, identifier in pairs(identifiers) do
-        state:set(type, identifier, false)
-    end
 
     return player
 end

--- a/server/player/registry.lua
+++ b/server/player/registry.lua
@@ -1,11 +1,34 @@
+local db = require 'player.db'
+
 ---@type { [number]: CPlayer }
 local PlayerRegistry = {}
+local PlayerIdFromUserId = {}
 
----@type { [number]: CPlayer }
+---@type { [number]: boolean }
 local connectingPlayers = {}
 
----@type { [string]: true }
-local activeIdentifiers = {}
+local function AddPlayer(playerId, userId)
+    local player = Player.new(playerId, userId)
+
+    PlayerRegistry[playerId] = player
+    PlayerIdFromUserId[userId] = playerId
+end
+
+local function RemovePlayer(player)
+    PlayerRegistry[player.source] = nil
+    PlayerIdFromUserId[player.userid] = nil
+end
+
+local function AssignNonTemporaryId(player, newId)
+    local oldId = player.source
+
+    PlayerRegistry[oldId] = nil
+    PlayerRegistry[newId] = player
+
+    PlayerIdFromUserId[player.userid] = newId
+    
+    player.setAsJoined(newId)
+end
 
 ---Returns an instance of CPlayer belonging to the given playerId.
 ---@param playerId number
@@ -14,6 +37,15 @@ function Ox.GetPlayer(playerId)
     return PlayerRegistry[playerId]
 end
 
+function Ox.GetPlayerFromUserId(userId)
+    local playerId = PlayerIdFromUserId[userId]
+    
+    return playerId and Ox.GetPlayer(playerId) or nil
+end
+
+function Ox.GetAllPlayers()
+    return PlayerRegistry
+end
 ---Check if a player matches filter parameters.
 ---@param player CPlayer
 ---@param filter table
@@ -38,7 +70,7 @@ end
 ---@param filter table
 ---@return CPlayer?
 function Ox.GetPlayerByFilter(filter)
-    for _, player in pairs(PlayerRegistry) do
+    for _, player in pairs(Ox.GetAllPlayers()) do
         if player.charid then
             if filterPlayer(player, filter) then
                 return player
@@ -54,7 +86,7 @@ function Ox.GetPlayers(filter)
     local size = 0
     local players = {}
 
-    for _, player in pairs(PlayerRegistry) do
+    for _, player in pairs(Ox.GetAllPlayers()) do
         if player.charid then
             if not filter or filterPlayer(player, filter) then
                 size += 1
@@ -69,36 +101,32 @@ end
 local serverLockdown
 
 RegisterNetEvent('ox:playerJoined', function()
+    local playerId = source
+
     if serverLockdown then
-        return DropPlayer(source, serverLockdown)
+        return DropPlayer(playerId, serverLockdown)
     end
 
-    local player = PlayerRegistry[source]
+    local player = Ox.GetPlayer(playerId)
 
-    if not player then
-        local identifiers = Ox.GetIdentifiers(source)
-        activeIdentifiers[identifiers[Server.PRIMARY_IDENTIFIER]] = true
-        player = Player.new(source, identifiers)
-        PlayerRegistry[player.source] = player
-    end
+    player.characters = Player.selectCharacters(playerId, player.userid)
 
-    player.characters = Player.selectCharacters(player.source, player.userid)
-
-    TriggerClientEvent('ox:selectCharacter', player.source, player.characters)
+    TriggerClientEvent('ox:selectCharacter', playerId, player.characters)
 end)
 
 AddEventHandler('playerJoining', function(tempId)
-    tempId = tonumber(tempId) --[[@as number why the hell is this a string]]
-    local identifiers = connectingPlayers[tempId]
+    local playerId = source
 
-    if identifiers then
-        connectingPlayers[tempId] = nil
-        local player = Player.new(source, identifiers)
-        PlayerRegistry[player.source] = player
-    end
+    tempId = tonumber(tempId) --[[@as number why the hell is this a string]]
+
+    connectingPlayers[tempId] = nil
+
+    local player = Ox.GetPlayer(tempId)
+
+    AssignNonTemporaryId(player, playerId)
 end)
 
-AddEventHandler('playerConnecting', function(_, _, deferrals)
+AddEventHandler('playerConnecting', function(username, _, deferrals)
     local tempId = source
     deferrals.defer()
 
@@ -111,26 +139,32 @@ AddEventHandler('playerConnecting', function(_, _, deferrals)
 
     if not primaryIdentifier then
         return deferrals.done(("unable to determine '%s' identifier."):format(Server.PRIMARY_IDENTIFIER))
-    elseif not Shared.DEBUG and activeIdentifiers[primaryIdentifier] then
+    elseif not Shared.DEBUG and PlayerRegistry[primaryIdentifier] then
         return deferrals.done(("identifier '%s:%s' is already active."):format(Server.PRIMARY_IDENTIFIER, primaryIdentifier))
     end
 
-    activeIdentifiers[primaryIdentifier] = true
-    connectingPlayers[tempId] = identifiers
+    local userid = db.getUserFromIdentifier(identifiers[Server.PRIMARY_IDENTIFIER])
+
+    if not userid then
+        userid = db.createUser(username, identifiers) --[[@as number]]
+    end
+    
+    AddPlayer(tempId, userid)
+
+    connectingPlayers[tempId] = true
 
     deferrals.done()
 end)
 
 CreateThread(function()
     while true do
-        Wait(30000)
+        Wait(3000)
 
         -- If a player quits during the connection phase (and before joining), the tempId may stay
         -- active for several minutes.
-        for tempId, identifiers in pairs(connectingPlayers) do
+        for tempId in pairs(connectingPlayers) do
             ---@diagnostic disable-next-line: param-type-mismatch
-            if not GetPlayerEndpoint(tempId) then
-                activeIdentifiers[identifiers[Server.PRIMARY_IDENTIFIER]] = nil
+            if GetPlayerEndpoint(tempId) == 0x7FFFFFFF then
                 connectingPlayers[tempId] = nil
             end
         end
@@ -142,32 +176,34 @@ AddEventHandler('txAdmin:events:serverShuttingDown', function()
 
     Player.saveAll()
 
-    for playerId, player in pairs(PlayerRegistry) do
+    for playerId, player in pairs(Ox.GetAllPlayers()) do
         player.charid = nil
         DropPlayer(playerId, 'Server is restarting.')
     end
 end)
 
 AddEventHandler('playerDropped', function()
-    local player = PlayerRegistry[source]
+    local playerId = source
+
+    local player = Ox.GetPlayer(playerId)
     local primaryIdentifier
+
+    --[[ Why wouldn't there be a player here? ]]
 
     if player then
         primaryIdentifier = player.get(Server.PRIMARY_IDENTIFIER)
         player.logout(true)
-    else
-        primaryIdentifier = Ox.GetIdentifiers(source)?[Server.PRIMARY_IDENTIFIER]
-    end
 
-    if primaryIdentifier then
-        activeIdentifiers[primaryIdentifier] = nil
+        RemovePlayer(player)
+    else
+        primaryIdentifier = Ox.GetIdentifiers(playerId)?[Server.PRIMARY_IDENTIFIER]
     end
 end)
 
 ---@todo proper logout system, and make the command admin-only
-RegisterCommand('logout', function(source)
+RegisterCommand('logout', function(playerId)
     CreateThread(function()
-        local player = PlayerRegistry[source]
+        local player = Ox.GetPlayer(playerId)
         return player and player.logout()
     end)
 end)

--- a/server/player/registry.lua
+++ b/server/player/registry.lua
@@ -12,9 +12,6 @@ local function AddPlayer(playerId, userId)
 
     PlayerRegistry[playerId] = player
     PlayerIdFromUserId[userId] = playerId
-
-    --[[ TODO: Will probably be used for a reconnection(on core restart) logic or so. ]]
-    player.getState():set('userId', userId, false)
 end
 
 local function RemovePlayer(player, reason)
@@ -34,6 +31,9 @@ local function AssignNonTemporaryId(player, newId)
     PlayerIdFromUserId[player.userid] = newId
     
     player.setAsJoined(newId)
+
+    --[[ TODO: Will probably be used for a reconnection(on core restart) logic or so. ]]
+    player.getState():set('userId', player.userid, false)
 end
 
 ---Returns an instance of CPlayer belonging to the given playerId.


### PR DESCRIPTION
…ion, as soon as a valid userid is retrieved.

removed weird direct access to Player Registry.
actually invalidate connections if players cancel connection while deferring. naming convention for player ids is `playerId` instead of `source` now.