### PR TITLE
inService accessable on a clientside

### DIFF
--- a/server/player/events.lua
+++ b/server/player/events.lua
@@ -150,10 +150,10 @@ RegisterNetEvent('ox:setPlayerInService', function(job)
 
     if player and player.charid then
         if job and player.private.groups[job] then
-            return player:set('inService', job)
+            return player:set('inService', job, true)
         end
 
-        player:set('inService', false)
+        player:set('inService', false, true)
     end
 end)
 


### PR DESCRIPTION
inService should also be available on the client side. For example, when listing all my groups to indicate the group in which I am inService. Not sure if its the best to replicate the value or set a statebag and hook a statebag change.