### PR TITLE
Fix falling at spawn

### DIFF
--- a/client/spawn.lua
+++ b/client/spawn.lua
@@ -157,6 +157,7 @@ local function spawnPlayer(coords)
 	RequestCollisionAtCoord(coords.x, coords.y, coords.z)
 	SetEntityCoordsNoOffset(cache.ped, coords.x, coords.y, coords.z, false, false, false)
     SetEntityHeading(cache.ped, coords.w)
+	FreezeEntityPosition(cache.ped, true)
     SetGameplayCamRelativeHeading(0)
 
     while GetPlayerSwitchState() ~= 5 do Wait(0) end
@@ -164,6 +165,9 @@ local function spawnPlayer(coords)
     SwitchInPlayer(cache.ped)
 
     while GetPlayerSwitchState() ~= 12 do Wait(0) end
+    
+    while not HasCollisionLoadedAroundEntity(cache.ped) do Wait(0) end
+	FreezeEntityPosition(cache.ped, false)
 end
 
 RegisterNUICallback('selectSpawn', function(data, cb)


### PR DESCRIPTION
Player Ped was loading on some clients before collisions. Tested on a few potato PCs, unable reproduce initial bug after changes.