### PR TITLE
Option to disable default vehicle commands

### DIFF
--- a/server/vehicle/commands.lua
+++ b/server/vehicle/commands.lua
@@ -1,59 +1,57 @@
-if Shared.VEHICLE_COMMANDS then
-    local function deleteVehicle(entity)
-        local vehicle = Ox.GetVehicle(entity)
-        return vehicle and vehicle:despawn() or DeleteEntity(entity)
-    end
-    
-    lib.addCommand('group.admin', 'car', function(source, args)
-        local ped = GetPlayerPed(source)
-        local entity = GetVehiclePedIsIn(ped)
-    
-        if entity then
-            deleteVehicle(entity)
-        end
-    
-        if args.owner and args.owner > 0 then
-            args.owner = Ox.GetPlayer(args.owner)?.charid
-        end
-    
-        local vehicle = Ox.CreateVehicle({
-            owner = args.owner,
-            model = args.model,
-        }, GetEntityCoords(ped), GetEntityHeading(ped))
-    
-        if vehicle then
-            for i = 1, 50 do
-                Wait(0)
-                SetPedIntoVehicle(ped, vehicle.entity, -1)
-    
-                if GetVehiclePedIsIn(ped, false) == vehicle.entity then
-                    break
-                end
-            end
-        end
-    end, {'model:string', 'owner:?number'})
-    
-    lib.addCommand('group.admin', 'dv', function(source, args)
-        local ped = GetPlayerPed(source)
-        local entity = GetVehiclePedIsIn(ped)
-    
-        if entity > 0 then
-            return deleteVehicle(entity)
-        end
-    
-        local vehicles = lib.callback.await('ox:getNearbyVehicles', source, args.radius)
-    
-        for i = 1, #vehicles do
-            entity = NetworkGetEntityFromNetworkId(vehicles[i])
-            local vehicle = Ox.GetVehicle(entity)
-    
-            if vehicle then
-                if args.owned == 'true' then
-                    vehicle:despawn()
-                end
-            else
-                DeleteEntity(entity)
-            end
-        end
-    end, {'radius:?number', 'owned:?string'})
+local function deleteVehicle(entity)
+    local vehicle = Ox.GetVehicle(entity)
+    return vehicle and vehicle:despawn() or DeleteEntity(entity)
 end
+
+lib.addCommand('group.admin', 'car', function(source, args)
+    local ped = GetPlayerPed(source)
+    local entity = GetVehiclePedIsIn(ped)
+
+    if entity then
+        deleteVehicle(entity)
+    end
+
+    if args.owner and args.owner > 0 then
+        args.owner = Ox.GetPlayer(args.owner)?.charid
+    end
+
+    local vehicle = Ox.CreateVehicle({
+        owner = args.owner,
+        model = args.model,
+    }, GetEntityCoords(ped), GetEntityHeading(ped))
+
+    if vehicle then
+        for i = 1, 50 do
+            Wait(0)
+            SetPedIntoVehicle(ped, vehicle.entity, -1)
+
+            if GetVehiclePedIsIn(ped, false) == vehicle.entity then
+                break
+            end
+        end
+    end
+end, {'model:string', 'owner:?number'})
+
+lib.addCommand('group.admin', 'dv', function(source, args)
+    local ped = GetPlayerPed(source)
+    local entity = GetVehiclePedIsIn(ped)
+
+    if entity > 0 then
+        return deleteVehicle(entity)
+    end
+
+    local vehicles = lib.callback.await('ox:getNearbyVehicles', source, args.radius)
+
+    for i = 1, #vehicles do
+        entity = NetworkGetEntityFromNetworkId(vehicles[i])
+        local vehicle = Ox.GetVehicle(entity)
+
+        if vehicle then
+            if args.owned == 'true' then
+                vehicle:despawn()
+            end
+        else
+            DeleteEntity(entity)
+        end
+    end
+end, {'radius:?number', 'owned:?string'})

--- a/server/vehicle/commands.lua
+++ b/server/vehicle/commands.lua
@@ -1,57 +1,59 @@
-local function deleteVehicle(entity)
-    local vehicle = Ox.GetVehicle(entity)
-    return vehicle and vehicle:despawn() or DeleteEntity(entity)
-end
-
-lib.addCommand('group.admin', 'car', function(source, args)
-    local ped = GetPlayerPed(source)
-    local entity = GetVehiclePedIsIn(ped)
-
-    if entity then
-        deleteVehicle(entity)
-    end
-
-    if args.owner and args.owner > 0 then
-        args.owner = Ox.GetPlayer(args.owner)?.charid
-    end
-
-    local vehicle = Ox.CreateVehicle({
-        owner = args.owner,
-        model = args.model,
-    }, GetEntityCoords(ped), GetEntityHeading(ped))
-
-    if vehicle then
-        for i = 1, 50 do
-            Wait(0)
-            SetPedIntoVehicle(ped, vehicle.entity, -1)
-
-            if GetVehiclePedIsIn(ped, false) == vehicle.entity then
-                break
-            end
-        end
-    end
-end, {'model:string', 'owner:?number'})
-
-lib.addCommand('group.admin', 'dv', function(source, args)
-    local ped = GetPlayerPed(source)
-    local entity = GetVehiclePedIsIn(ped)
-
-    if entity > 0 then
-        return deleteVehicle(entity)
-    end
-
-    local vehicles = lib.callback.await('ox:getNearbyVehicles', source, args.radius)
-
-    for i = 1, #vehicles do
-        entity = NetworkGetEntityFromNetworkId(vehicles[i])
+if Shared.VEHICLE_COMMANDS then
+    local function deleteVehicle(entity)
         local vehicle = Ox.GetVehicle(entity)
-
-        if vehicle then
-            if args.owned == 'true' then
-                vehicle:despawn()
-            end
-        else
-            DeleteEntity(entity)
-        end
+        return vehicle and vehicle:despawn() or DeleteEntity(entity)
     end
-end, {'radius:?number', 'owned:?string'})
+    
+    lib.addCommand('group.admin', 'car', function(source, args)
+        local ped = GetPlayerPed(source)
+        local entity = GetVehiclePedIsIn(ped)
+    
+        if entity then
+            deleteVehicle(entity)
+        end
+    
+        if args.owner and args.owner > 0 then
+            args.owner = Ox.GetPlayer(args.owner)?.charid
+        end
+    
+        local vehicle = Ox.CreateVehicle({
+            owner = args.owner,
+            model = args.model,
+        }, GetEntityCoords(ped), GetEntityHeading(ped))
+    
+        if vehicle then
+            for i = 1, 50 do
+                Wait(0)
+                SetPedIntoVehicle(ped, vehicle.entity, -1)
+    
+                if GetVehiclePedIsIn(ped, false) == vehicle.entity then
+                    break
+                end
+            end
+        end
+    end, {'model:string', 'owner:?number'})
+    
+    lib.addCommand('group.admin', 'dv', function(source, args)
+        local ped = GetPlayerPed(source)
+        local entity = GetVehiclePedIsIn(ped)
+    
+        if entity > 0 then
+            return deleteVehicle(entity)
+        end
+    
+        local vehicles = lib.callback.await('ox:getNearbyVehicles', source, args.radius)
+    
+        for i = 1, #vehicles do
+            entity = NetworkGetEntityFromNetworkId(vehicles[i])
+            local vehicle = Ox.GetVehicle(entity)
+    
+            if vehicle then
+                if args.owned == 'true' then
+                    vehicle:despawn()
+                end
+            else
+                DeleteEntity(entity)
+            end
+        end
+    end, {'radius:?number', 'owned:?string'})
+end

--- a/server/vehicle/main.lua
+++ b/server/vehicle/main.lua
@@ -2,7 +2,7 @@ local Vehicle = {}
 local db = require 'server.vehicle.db'
 local VehicleRegistry = require 'server.vehicle.registry'
 
-require 'server.vehicle.commands'
+if Shared.VEHICLE_COMMANDS then require 'server.vehicle.commands' end
 
 ---Save all vehicles for the resource and despawn them.
 ---@param resource string?

--- a/shared/main.lua
+++ b/shared/main.lua
@@ -8,6 +8,7 @@ Ox = setmetatable({}, {
 Shared = {
     SV_LAN = GetConvar('sv_lan', 'false') == 'true',
     CHARACTER_SLOTS = GetConvarInt('ox:characterSlots', 5),
+    VEHICLE_COMMANDS = GetConvarInt('ox:vehicleCommands', 1) == 1,
 }
 
 Shared.DEBUG = Shared.SV_LAN or GetConvarInt('ox:debug', 0) == 1


### PR DESCRIPTION
The reason is more or less simple, I believe a lot of servers use their own system to spawn vehicles that use identical 'car' and 'dv' commands