### PR TITLE
fix (ox_core/client): Duplicating tattoos from character to character

### DIFF
--- a/client/spawn.lua
+++ b/client/spawn.lua
@@ -34,7 +34,7 @@ end
 local function startPlayerCustomisation(model)
     if not fivem_appearance then return end
 
-    setPlayerAppearance({ model = model })
+    setPlayerAppearance({ model = model, tattoos = {} })
 
     local p = promise.new()
 


### PR DESCRIPTION
I do not have currently an option to make a video of it so lemme quickly describe it

1. Select already created character that has a tattos (otherwise create a new character, apply tattos and logout back to character selection)
2. Make sure your character is selected and ped is visible
3. Create a new character
4. Your character will have a tattos of a character that you have had selected before you started creating a new character, or you can select random tattoos during a character creation in fivem-appearance and those tattos will appears also

This does not happen when you have not selected other character before you create a new character

I hope it makes sense, if not I will make a video later