### PR TITLE
fix(server/player): Use existing gender information

### DIFF
--- a/server/player/events.lua
+++ b/server/player/events.lua
@@ -86,7 +86,7 @@ RegisterNetEvent('ox:selectCharacter', function(data)
         userid = player.userid,
         charid = player.charid,
         groups = player:getGroups(),
-    }, cData.health, cData.armour, player:get('gender'))
+    }, cData.health, cData.armour, cData.gender)
 
     state:set('dead', player:get('isDead'), true)
     state:set('name', player.name, true)


### PR DESCRIPTION
* Since moving the `player:set` calls after the `ox:loadPlayer` event player doesn't have the gender field set yet, so we should use cData.gender instead