### PR TITLE
fix(server/player/class): param type extra closing curly brace

### DIFF
--- a/server/player/class.lua
+++ b/server/player/class.lua
@@ -97,7 +97,7 @@ end
 
 ---Checks if the player has any groups matching the filter, returning the first match.
 ---The filter be the group, an array of groups, or a map where key is the group and value is the minimum grade.
----@param filter string | string[] | table<string, number> }
+---@param filter string | string[] | table<string, number>
 ---@return string? group, number? grade
 function OxPlayer:hasGroup(filter)
     local type = type(filter)


### PR DESCRIPTION
Almost nothing but it triggered me lol
The type of `filter` is defined as `string | string[] | table<string, number> }`.
It seems there's an extra closing curly brace `}` at the end that seems to be a typo.