### PR TITLE
fix(client/death): default skin on player death

### DIFF
--- a/client/death.lua
+++ b/client/death.lua
@@ -134,6 +134,7 @@ function onPlayerDeath()
     playerState.dead = false
 
     TriggerServerEvent('ox:playerDeath', false)
+    exports['fivem-appearance']:setPlayerAppearance(cache.appearance)
 end
 
 local function startDeathLoop()
@@ -142,6 +143,7 @@ local function startDeathLoop()
         cache.ped = PlayerPedId()
 
         if not PlayerIsDead and IsPedDeadOrDying(cache.ped, false) then
+            cache.appearance = exports['fivem-appearance']:getPedAppearance(cache.ped)
             onPlayerDeath()
         end
     end


### PR DESCRIPTION
## Issue

On player death, the skin is set to the default [see video](https://discord.com/channels/813030955598086174/951683419769831465/1137135623589875823). The issue appears to be related to how FiveM handles player respawns.

## Changes Made

I've investigated the issue and found that by triggering `NetworkResurrectLocalPlayer` before the `Wait(1900)` line 35, the native FiveM teleportation can be prevented. However, due to uncertainty about the intended behavior, this PR focuses on setting the appearance back to default upon death.

## Proposed Solution

With this PR, the player's appearance is now saved before death and is re-applied once the player spawns at the hospital.