### PR TITLE
fix(server/db): sync health on player spawn

### DIFF
--- a/server/player/events.lua
+++ b/server/player/events.lua
@@ -95,7 +95,7 @@ RegisterNetEvent('ox:selectCharacter', function(data)
         charId = player.charId,
         stateId = player.stateId,
         groups = player:getGroups(),
-    }, player:get('isDead') and 0 or cData.health, cData.armour, cData.gender)
+    }, cData.isDead and 0 or cData.health, cData.armour, cData.gender)
 
     player:set('dateOfBirth', cData.dateOfBirth, true)
     player:set('gender', cData.gender, true)


### PR DESCRIPTION
Get correct data for `isDead` stored in DB.