### PR TITLE
fix(shared/init) GetExport issue with stopped resources

### DIFF
--- a/shared/init.lua
+++ b/shared/init.lua
@@ -31,7 +31,8 @@ function GetExport(name)
         return exp
     end
 
-    if GetResourceState(name) ~= 'missing' then
+    local resourceState = GetResourceState(name) 
+    if resourceState ~= 'missing' and resourceState ~= 'stopped' then
         expCache[name] = exports[name]
         return expCache[name]
     end


### PR DESCRIPTION
* If a resource is not missing but it's stopped GetExport will still try to cache it