### PR TITLE
feat(server/player): add toggle option for `setPlayerInService` event

### DIFF
--- a/server/player/events.lua
+++ b/server/player/events.lua
@@ -144,15 +144,13 @@ RegisterNetEvent('ox:playerDeath', function(state)
     end
 end)
 
-RegisterNetEvent('ox:setPlayerInService', function(job)
+RegisterNetEvent('ox:setPlayerInService', function(job, state)
     local player = Ox.GetPlayer(source)
-
     if player and player.charId then
-        if job and player:getGroup(job) then
+        if job and player:getGroup(job) and (state or state == nil) then
             return player:set('inService', job, true)
         end
 
         player:set('inService', false, true)
     end
 end)
-


### PR DESCRIPTION
This change it's a non break change for actual users of the core, because if state parameter is nil it will set to true.  But this give the options for set inService as false with an event for new scripts to handle groups.