### PR TITLE
fix(groups): add admin grade to oxgroup

### DIFF
--- a/server/groups/index.ts
+++ b/server/groups/index.ts
@@ -9,11 +9,12 @@ export function GetGroup(name: string) {
   return groups[name];
 }
 
-async function CreateGroup({ name, grades, label }: OxGroup) {
+async function CreateGroup({ name, grades, label, adminGrade }: OxGroup) {
   const group: OxGroup = {
     name,
     label,
     grades: JSON.parse(grades as any),
+    adminGrade,
     principal: `group.${name}`,
   };
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -124,5 +124,6 @@ export interface OxGroup {
   name: string;
   label: string;
   grades: [null, ...string[]];
+  adminGrade: number;
   principal: string;
 }


### PR DESCRIPTION
Fixing a bug where since the TS rework adminGrade was not present anymore in OxGroup