### PR TITLE
fix(vehicle): change method to get date seconds in vin generation

### DIFF
--- a/server/vehicle/class.ts
+++ b/server/vehicle/class.ts
@@ -57,7 +57,7 @@ export class OxVehicle extends ClassInterface {
       vehicle.model.slice(0, 2).toUpperCase(),
       null,
       null,
-      +Date() / 1000,
+      Math.floor(Date.now() / 1000),
     ];
 
     while (true) {


### PR DESCRIPTION
The actual method `+Date() / 1000` return Not a number so it's generate VIN with this format `9OXSU2VNaN`