### PR TITLE
feat(accounts/transactions): add transactions stuff

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -12,5 +12,7 @@
   "male": "Male",
   "female": "Female",
   "non_binary": "Non-Binary",
-  "date_of_birth": "Date of birth"
+  "date_of_birth": "Date of birth",
+  "withdraw": "Withdraw",
+  "deposit": "Deposit"
 }

--- a/server/accounts/index.ts
+++ b/server/accounts/index.ts
@@ -36,16 +36,16 @@ export function GetGroupAccounts(group: string) {
   return SelectAccounts('group', group);
 }
 
-export function AddAccountBalance(id: number, amount: number) {
-  return UpdateBalance(id, amount, 'add');
+export function AddAccountBalance(id: number, amount: number, message?: string) {
+  return UpdateBalance(id, amount, 'add', false, message);
 }
 
-export function RemoveAccountBalance(id: number, amount: number, overdraw = false) {
-  return UpdateBalance(id, amount, 'remove', overdraw);
+export function RemoveAccountBalance(id: number, amount: number, overdraw = false, message?: string) {
+  return UpdateBalance(id, amount, 'remove', overdraw, message);
 }
 
-export function TransferAccountBalance(fromId: number, toId: number, amount: number, overdraw = false) {
-  return PerformTransaction(fromId, toId, amount, overdraw);
+export function TransferAccountBalance(fromId: number, toId: number, amount: number, overdraw = false, message?: string) {
+  return PerformTransaction(fromId, toId, amount, overdraw, message);
 }
 
 export function CreateAccount(charId: number, label: string, shared?: boolean) {

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -204,6 +204,23 @@ CREATE TABLE `accounts_access`
             ON DELETE CASCADE
 );
 
+CREATE TABLE `accounts_transactions`
+(
+    `id`         INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    `fromId`     INT UNSIGNED,
+    `toId`       INT UNSIGNED,
+    `amount`     INT          NOT NULL,
+    `message`    VARCHAR(50),
+    `date`       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`id`),
+    CONSTRAINT `accounts_transactions__fromId_fk`
+        FOREIGN KEY (`fromId`) REFERENCES `accounts` (`id`)
+            ON DELETE CASCADE,
+    CONSTRAINT `accounts_transactions__toId_fk`
+        FOREIGN KEY (`toId`) REFERENCES `accounts` (`id`)
+            ON DELETE CASCADE
+);
+
 /*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;
 
 /*!40014 SET FOREIGN_KEY_CHECKS=IFNULL(@OLD_FOREIGN_KEY_CHECKS, 1) */;


### PR DESCRIPTION
This PR implements basics transactions logs in db to retrieves transactions in ox_banking https://github.com/overextended/ox_banking/pull/7

Ex :
`exports.ox_core:AddAccountBalance(account.id, 450, "Salary")`
`exports.ox_core:RemoveAccountBalance(account.id, 350000, false, "Premium Deluxe Motorsport")`