### PR TITLE
fix(lib/player): get metadata at first spawn

### DIFF
--- a/lib/client/player.lua
+++ b/lib/client/player.lua
@@ -51,7 +51,7 @@ function OxPlayer:get(key)
         end)
 
         getters[key] = true
-        self[key] = self:__call('get', key);
+        self[key] = OxPlayer:__call('get', key);
     end
 
     return self[key]


### PR DESCRIPTION
If you spawn at the first time, metadata can't be call, `__call method does not exist`