### PR TITLE
fix(server/groups): grades unshift

### DIFF
--- a/server/groups/index.ts
+++ b/server/groups/index.ts
@@ -17,8 +17,6 @@ async function CreateGroup({ name, grades, label }: OxGroup) {
     principal: `group.${name}`,
   };
 
-  group.grades.unshift(null);
-
   let parent = group.principal;
 
   for (let i = 0; i < group.grades.length; i++) {

--- a/server/groups/index.ts
+++ b/server/groups/index.ts
@@ -19,7 +19,7 @@ async function CreateGroup({ name, grades, label }: OxGroup) {
 
   let parent = group.principal;
 
-  for (let i = 0; i < group.grades.length; i++) {
+  for (let i = 1; i <= group.grades.length; i++) {
     const child = `${group.principal}:${i}`;
 
     if (!IsPrincipalAceAllowed(child, child)) {
@@ -43,7 +43,7 @@ function DeleteGroup(group: OxGroup) {
 
   removeAce(parent, parent, true);
 
-  for (let i = 0; i < group.grades.length; i++) {
+  for (let i = 1; i <= group.grades.length; i++) {
     const child = `${group.principal}:${i}`;
 
     removeAce(child, child, true);

--- a/server/player/class.ts
+++ b/server/player/class.ts
@@ -190,8 +190,8 @@ export class OxPlayer extends ClassInterface {
 
       this.#removeGroup(group, currentGrade);
     } else {
-      if (!group.grades[grade] && grade > 0)
-        console.warn(`Failed to set OxPlayer<${this.userId}> ${group.name}:${grade} (invalid grade)`);
+      if (!group.grades[grade - 1] && grade > 0)
+        return console.warn(`Failed to set OxPlayer<${this.userId}> ${group.name}:${grade} (invalid grade)`);
 
       if (currentGrade) {
         if (!(await UpdateCharacterGroup(this.charId, group.name, grade))) return;


### PR DESCRIPTION
This PR fixes incorrect indexing of group grades

Before:
![image](https://github.com/overextended/ox_core/assets/8851795/b18d722f-3917-4537-94b5-3347ced26436)

After:
![image](https://github.com/overextended/ox_core/assets/8851795/938e2c5a-4dda-4bd2-9d80-e9620e54c253)
