### PR TITLE
fix(client/player): round status value to 8 decimals

### DIFF
--- a/client/player/status.ts
+++ b/client/player/status.ts
@@ -11,7 +11,7 @@ function UpdateStatuses() {
 
     OxPlayer.setStatus(
       name,
-      newValue < 0 ? 0 : newValue > 100 ? 100 : parseFloat((curValue + status.onTick).toPrecision(4))
+      newValue < 0 ? 0 : newValue > 100 ? 100 : parseFloat((curValue + status.onTick).toPrecision(8))
     );
   }
 


### PR DESCRIPTION
This PR fixes following:

After https://github.com/overextended/ox_core/commit/4e7a126bc8bee392efd3ac040093d80e7cbd151b onTick change, value was rounded to only 4 decimals instead of 8