### PR TITLE
fix(client/vehicle): filter undefined values in vehicle parser

### DIFF
--- a/client/vehicle/parser.ts
+++ b/client/vehicle/parser.ts
@@ -26,6 +26,7 @@ onServerCallback('ox:generateVehicleData', async (parseAll: boolean) => {
 
       return parseAll ? vehicle : GetVehicleData(vehicle) ? undefined : vehicle;
     })
+    .filter((vehicle?: string) => vehicle)
     .sort();
 
   SetPlayerControl(cache.playerId, false, 1 << 8);


### PR DESCRIPTION
Fixes an error when parsing only _new_ vehicles (`parseAll` set to false).

The function would throw error when requesting the undefined vehicle model.
It should instead skip this vehicle since it already exists - which is done by filtering the values.