### PR TITLE
feat(accounts): accounts Id, from/toBalance, notes and return values

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -14,5 +14,6 @@
   "non_binary": "Non-Binary",
   "date_of_birth": "Date of birth",
   "withdraw": "Withdraw",
-  "deposit": "Deposit"
+  "deposit": "Deposit",
+  "transfer": "Bank transfer"
 }

--- a/server/accounts/index.ts
+++ b/server/accounts/index.ts
@@ -44,8 +44,8 @@ export function RemoveAccountBalance(id: number, amount: number, overdraw = fals
   return UpdateBalance(id, amount, 'remove', overdraw, message);
 }
 
-export function TransferAccountBalance(fromId: number, toId: number, amount: number, overdraw = false, message?: string) {
-  return PerformTransaction(fromId, toId, amount, overdraw, message);
+export function TransferAccountBalance(fromId: number, toId: number, amount: number, overdraw = false, message?: string, note?: string, actorId?: number) {
+  return PerformTransaction(fromId, toId, amount, overdraw, message, note, actorId);
 }
 
 export function CreateAccount(charId: number, label: string, shared?: boolean) {

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,1 +1,3 @@
 export * from '../common/config';
+
+export const CREATE_DEFAULT_ACCOUNT = GetConvarInt('ox:createDefaultAccount', 1) === 1;

--- a/server/player/events.ts
+++ b/server/player/events.ts
@@ -5,6 +5,7 @@ import { db } from 'db';
 import { Statuses } from './status';
 import { CreateNewAccount } from 'accounts/db';
 import { Dict, NewCharacter, OxStatus } from 'types';
+import { CREATE_DEFAULT_ACCOUNT } from 'config';
 
 type ScopeEvent = { player: string; for: string };
 
@@ -111,7 +112,9 @@ onClientCallback('ox:deleteCharacter', async (playerId, charId: number) => {
 
 on('ox:createdCharacter', async (playerId: number, userId: number, charId: number) => {
   db.execute('INSERT INTO character_inventory (charId) VALUES (?)', [charId]);
-  CreateNewAccount('owner', charId, 'Personal', false, true);
+
+  if (CREATE_DEFAULT_ACCOUNT)
+    CreateNewAccount('owner', charId, 'Personal', false, true);
 });
 
 onNet('ox:updateStatuses', async (data: Dict<OxStatus>) => {

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -167,14 +167,19 @@ CREATE TABLE IF NOT EXISTS `accounts_access` (
 
 CREATE TABLE IF NOT EXISTS `accounts_transactions` (
   `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
-  `fromId` INT UNSIGNED NULL DEFAULT NULL,
-  `toId` INT UNSIGNED NULL DEFAULT NULL,
+  `actorId` INT UNSIGNED DEFAULT NULL,
+  `fromId` INT UNSIGNED DEFAULT NULL,
+  `toId` INT UNSIGNED DEFAULT NULL,
   `amount` INT NOT NULL,
-  `message` VARCHAR(50),
+  `message` VARCHAR(255) NOT NULL,
+  `note` VARCHAR(255) DEFAULT NULL,
+  `fromBalance` INT DEFAULT NULL,
+  `toBalance` INT DEFAULT NULL,
   `date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
-  CONSTRAINT `accounts_transactions__fromId_fk` FOREIGN KEY (`fromId`) REFERENCES `accounts` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `accounts_transactions__toId_fk` FOREIGN KEY (`toId`) REFERENCES `accounts` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  CONSTRAINT `accounts_transactions_actorId_fk` FOREIGN KEY (`actorId`) REFERENCES `characters` (`charId`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `accounts_transactions_fromId_fk` FOREIGN KEY (`fromId`) REFERENCES `accounts` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `accounts_transactions_toId_fk` FOREIGN KEY (`toId`) REFERENCES `accounts` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 /*!40101 SET SQL_MODE=IFNULL(@OLD_SQL_MODE, '') */;

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -144,7 +144,7 @@ CREATE TABLE IF NOT EXISTS `character_licenses` (
 );
 
 CREATE TABLE IF NOT EXISTS `accounts` (
-  `id` INT(6) UNSIGNED AUTO_INCREMENT,
+  `id` INT(6) UNSIGNED NOT NULL,
   `label` VARCHAR(50) NOT NULL,
   `owner` INT UNSIGNED NULL,
   `group` VARCHAR(20) NULL,
@@ -154,7 +154,7 @@ CREATE TABLE IF NOT EXISTS `accounts` (
   PRIMARY KEY (`id`),
   CONSTRAINT `accounts_owner_fk` FOREIGN KEY (`owner`) REFERENCES `characters` (`charId`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `accounts_group_fk` FOREIGN KEY (`group`) REFERENCES `ox_groups` (`name`) ON DELETE CASCADE ON UPDATE CASCADE
-) AUTO_INCREMENT = 100000;
+);
 
 CREATE TABLE IF NOT EXISTS `accounts_access` (
   `accountId` INT UNSIGNED NOT NULL,


### PR DESCRIPTION
This PR improves accounts with following changes:

1. Account Ids are no longer boring auto increments but are randomly generated to improve feeling
2. Added *createDefaultAccount* Convar in case default accounts are not desired
3. Added optional *note* column to transactions for a sake of having a way to have custom notes
4. Improved return values for better integration of accounts to 3rd party resources

Tested with:

```lua
RegisterCommand('createAccount', function(playerId, args)
    local OxPlayer = Ox.GetPlayer(playerId)
    if not OxPlayer or not OxPlayer.charId then return end

    local retval = Ox.CreateAccount(OxPlayer.charId, args[1])
    print(retval)
end)

RegisterCommand('transferBalance', function(playerId, args)
    local OxPlayer = Ox.GetPlayer(playerId)
    if not OxPlayer or not OxPlayer.charId then return end

    local fromId = tonumber(args[1])
    local toId = tonumber(args[2])
    local amount = tonumber(args[3])


    local retval = Ox.TransferAccountBalance(fromId, toId, amount, false, args[4], args[5], OxPlayer.charId)
    print(retval)
end)

RegisterCommand('withdrawMoney', function(playerId, args)
    local OxPlayer = Ox.GetPlayer(playerId)
    if not OxPlayer or not OxPlayer.charId then return end

    local accountId = tonumber(args[1])
    local amount = tonumber(args[2])

    local retval = Ox.WithdrawMoney(playerId, accountId, amount, nil, args[3])
    print(retval)
end)

RegisterCommand('depositMoney', function(playerId, args)
    local OxPlayer = Ox.GetPlayer(playerId)
    if not OxPlayer or not OxPlayer.charId then return end

    local accountId = tonumber(args[1])
    local amount = tonumber(args[2])

    local retval = Ox.DepositMoney(playerId, accountId, amount, nil, args[3])
    print(retval)
end)
```