### PR TITLE
fix(server/vehicle):  add undefined plate check

### DIFF
--- a/server/vehicle/index.ts
+++ b/server/vehicle/index.ts
@@ -55,11 +55,12 @@ export async function CreateVehicle(
   if (!data.vin && (data.owner || data.group)) data.vin = await OxVehicle.generateVin(vehicleData);
   if (data.vin && !data.owner && !data.group) delete data.vin;
 
-  data.plate = data.vin
-    ? data.plate!
-    : data.plate && (await IsPlateAvailable(data.plate))
+  data.plate =
+    data.vin && data.plate
       ? data.plate
-      : await OxVehicle.generatePlate();
+      : data.plate && (await IsPlateAvailable(data.plate))
+        ? data.plate
+        : await OxVehicle.generatePlate();
 
   const metadata = data.data || ({} as { properties: VehicleProperties; [key: string]: any });
   metadata.properties = metadata.properties || data.properties;


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/overextended/ox_core/commit/518b4674e0ab6c0d3f5a502cf883cd608f118c54 where `CreateVehicle` fails to insert vehicle data to the database when creating new vehicle due to plate being undefined.