### PR TITLE
fix(server/accounts): transaction new balance

### DIFF
--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -70,7 +70,7 @@ export async function UpdateBalance(
       amount,
       message,
       note,
-      addAction ? null : balance + amount,
+      addAction ? null : balance - amount,
       addAction ? balance + amount : null,
     ])) === 1;
 


### PR DESCRIPTION
When removing money using `account.removeBalance()` ox_banking transaction log shows the balance as if it was added. 

![image](https://github.com/user-attachments/assets/839c9d9a-05a0-4180-81d9-5e26b55b4b16)

![image](https://github.com/user-attachments/assets/a0572874-058f-4594-aa92-860a8c89d545)


[ox_banking uses from balance as newBalance](https://github.com/overextended/ox_banking/blob/main/src/server/index.ts#L534), so we are now updating the balance by taking away the amount if addAction is not "add".


