### PR TITLE
fix(server/player): remove group before removing active group

### DIFF
--- a/server/player/class.ts
+++ b/server/player/class.ts
@@ -196,9 +196,10 @@ export class OxPlayer extends ClassInterface {
     if (!grade) {
       if (!currentGrade) return;
       if (!(await RemoveCharacterGroup(this.charId, group.name))) return;
-      if (this.get('activeGroup') === groupName) this.set('activeGroup', undefined, true);
 
       this.#removeGroup(group, currentGrade);
+
+      if (this.get('activeGroup') === groupName) this.set('activeGroup', undefined, true);
     } else {
       if (!group.grades[grade] && grade > 0)
         return console.warn(`Failed to set OxPlayer<${this.userId}> ${group.name}:${grade} (invalid grade)`);


### PR DESCRIPTION
This PR fixes an issue where removing active group from player didn't properly update the `group:activeCount` GlobalState due to `activeGroup` being removed earlier that calling `removeGroup` method (which contains the GlobalState update).