### PR TITLE
fix(server/player/class): Incriment active group count in correct order

### DIFF
--- a/server/player/class.ts
+++ b/server/player/class.ts
@@ -401,8 +401,6 @@ export class OxPlayer extends ClassInterface {
 
     this.#groups[group.name] = grade;
     GlobalState[`${group.name}:count`] += 1;
-
-    if (group.name === this.get('activeGroup')) GlobalState[`${group.name}:activeCount`] += 1;
   }
 
   /** Removes the active character from the group and sets permissions. */
@@ -559,6 +557,9 @@ export class OxPlayer extends ClassInterface {
     this.set('dateOfBirth', dateOfBirth, true);
     this.set('phoneNumber', phoneNumber, true);
     this.set('activeGroup', groups.find((group) => group.isActive)?.name, true);
+
+    if (this.get('activeGroup')) GlobalState[`${this.get('activeGroup')}:activeCount`] += 1;
+    DEV: console.info(`Restored OxPlayer<${this.userId}> previous active group: ${this.get('activeGroup')}`);
 
     OxPlayer.keys.charId[character.charId] = this;
 


### PR DESCRIPTION
When a player disconnects/logs out while having an `activeGroup` the `groupName:activeCount` was getting decremented correctly, but when connecting afterwards it misses an increment due to it checking for `activeGroup` and attempting to increment before `activeGroup` gets set in the log in process.

This seems to fix it.