### PR TITLE
fix(server/vehicle) Delete vehicle entity on respawn, not delete from DB

### DIFF
--- a/server/vehicle/class.ts
+++ b/server/vehicle/class.ts
@@ -264,7 +264,7 @@ export class OxVehicle extends ClassInterface {
 
     OxVehicle.remove(this.entity);
 
-    if (hasEntity) DeleteVehicle(this.entity);
+    if (hasEntity) DeleteEntity(this.entity);
 
     this.entity = OxVehicle.spawn(this.model, coords, 0);
     this.netId = NetworkGetNetworkIdFromEntity(this.entity);


### PR DESCRIPTION
Currently, when calling `vehicle.respawn(...)` if the entity of the vehicle currently exists, it will attempt to delete the vehicle from the database rather than delete the entity.