### PR TITLE
feature(server/vehicle) Add support for getting OxVehicle even when vehicle not tracked

### DIFF
--- a/lib/server/vehicle.lua
+++ b/lib/server/vehicle.lua
@@ -4,7 +4,6 @@ local OxVehicle = lib.class('OxVehicle')
 
 function OxVehicle:__index(index)
     local value = OxVehicle[index] --[[@as any]]
-
     if type(value) == 'function' then
         self[index] = value == OxVehicle.__call and function(...)
             return value(self, index, ...)
@@ -25,7 +24,7 @@ function OxVehicle:constructor(data)
 end
 
 function OxVehicle:__call(...)
-    return exports.ox_core:CallVehicle(self.entity, ...)
+    return exports.ox_core:CallVehicle(self.internalId, ...)
 end
 
 function OxVehicle:__tostring()

--- a/lib/server/vehicle.ts
+++ b/lib/server/vehicle.ts
@@ -3,17 +3,19 @@ import type { CreateVehicleData } from 'server/vehicle';
 
 class VehicleInterface {
   constructor(
-    public entity: number,
-    public netId: number,
+    public internalId: string,
     public script: string,
     public plate: string,
     public model: string,
     public make: string,
     public id?: number,
+    public entity?: number,
+    public netId?: number,
     public vin?: string,
     public owner?: number,
     public group?: string
   ) {
+    this.internalId = internalId;
     this.entity = entity;
     this.netId = netId;
     this.script = script;
@@ -37,7 +39,7 @@ class VehicleInterface {
 
 Object.keys(exports.ox_core.GetVehicleCalls()).forEach((method: string) => {
   (VehicleInterface.prototype as any)[method] = function (...args: any[]) {
-    return exports.ox_core.CallVehicle(this.entity, method, ...args);
+    return exports.ox_core.CallVehicle(this.internalId, method, ...args);
   };
 });
 
@@ -51,13 +53,14 @@ function CreateVehicleInstance(vehicle?: _OxVehicle) {
   if (!vehicle) return;
 
   return new VehicleInterface(
-    vehicle.entity,
-    vehicle.netId,
+    vehicle.internalId,
     vehicle.script,
     vehicle.plate,
     vehicle.model,
     vehicle.make,
     vehicle.id,
+    vehicle.entity,
+    vehicle.netId,
     vehicle.vin,
     vehicle.owner,
     vehicle.group

--- a/lib/server/vehicle.ts
+++ b/lib/server/vehicle.ts
@@ -29,11 +29,11 @@ class VehicleInterface {
   }
 
   getCoords() {
-    return GetEntityCoords(this.entity);
+    return GetEntityCoords(this.entity!);
   }
 
   getState() {
-    return Entity(this.entity).state;
+    return Entity(this.entity!).state;
   }
 }
 

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -19,3 +19,12 @@ export function GetIdentifiers(playerId: number | string) {
 
   return identifiers;
 }
+
+export function GenerateUUID() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+
+    return v.toString(16);
+  });
+}

--- a/server/utils.ts
+++ b/server/utils.ts
@@ -19,12 +19,3 @@ export function GetIdentifiers(playerId: number | string) {
 
   return identifiers;
 }
-
-export function GenerateUUID() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-
-    return v.toString(16);
-  });
-}

--- a/server/vehicle/commands.ts
+++ b/server/vehicle/commands.ts
@@ -55,7 +55,8 @@ addCommand<{ radius?: number; owned?: string }>(
   async (playerId, args, raw) => {
     const ped = GetPlayerPed(playerId as any);
 
-    if (!args.radius) return DeleteCurrentVehicle(ped);
+    if (!args.radius && GetVehiclePedIsIn(ped, false) > 0) return DeleteCurrentVehicle(ped);
+    args.radius = args.radius ?? 2;
 
     const vehicles = await triggerClientCallback<number[]>('ox:getNearbyVehicles', playerId, args.radius);
 

--- a/server/vehicle/commands.ts
+++ b/server/vehicle/commands.ts
@@ -33,7 +33,7 @@ addCommand<{ model: string; owner?: number }>(
 
     DeleteCurrentVehicle(ped);
     await sleep(200);
-    SetPedIntoVehicle(ped, vehicle.entity, -1);
+    SetPedIntoVehicle(ped, vehicle.entity!, -1);
   },
   {
     help: `Spawn a vehicle with the given model.`,

--- a/server/vehicle/db.ts
+++ b/server/vehicle/db.ts
@@ -9,6 +9,7 @@ export type VehicleRow = {
   vin: string;
   model: string;
   data: { properties: VehicleProperties; [key: string]: any };
+  stored?: string;
 };
 
 setImmediate(() => db.query('UPDATE vehicles SET `stored` = ? WHERE `stored` IS NULL', ['impound']));
@@ -21,9 +22,16 @@ export async function IsVinAvailable(plate: string) {
   return !(await db.exists('SELECT 1 FROM vehicles WHERE vin = ?', [plate]));
 }
 
-export function GetStoredVehicleFromId(id: number) {
+export function GetVehicleFromVin(vin: string) {
   return db.row<VehicleRow>(
-    'SELECT id, owner, `group`, plate, vin, model, data FROM vehicles WHERE id = ? AND `stored` IS NOT NULL',
+    'SELECT id, owner, `group`, plate, vin, model, data, stored FROM vehicles WHERE vin = ?',
+    [vin]
+  );
+}
+
+export function GetVehicleFromId(id: number) {
+  return db.row<VehicleRow>(
+    'SELECT id, owner, `group`, plate, vin, model, data, stored FROM vehicles WHERE id = ?',
     [id]
   );
 }

--- a/server/vehicle/index.ts
+++ b/server/vehicle/index.ts
@@ -1,5 +1,5 @@
 import { OxVehicle } from './class';
-import { CreateNewVehicle, GetStoredVehicleFromId, IsPlateAvailable, VehicleRow } from './db';
+import { CreateNewVehicle, GetVehicleFromId, IsPlateAvailable, VehicleRow } from './db';
 import { GetVehicleData } from '../../common/vehicles';
 import { DEBUG } from '../../common/config';
 import './class';
@@ -39,7 +39,7 @@ export async function CreateVehicle(
     const vehicle = OxVehicle.getFromVehicleId(data.id);
 
     if (vehicle) {
-      if (DoesEntityExist(vehicle.entity)) {
+      if (vehicle.entity && DoesEntityExist(vehicle.entity)) {
         return vehicle;
       }
 
@@ -51,7 +51,6 @@ export async function CreateVehicle(
 
   const entity = coords ? OxVehicle.spawn(data.model, coords as Vector3, heading || 0) : 0;
 
-  if (!entity || !DoesEntityExist(entity)) return;
   if (!data.vin && (data.owner || data.group)) data.vin = await OxVehicle.generateVin(vehicleData);
   if (data.vin && !data.owner && !data.group) delete data.vin;
 
@@ -79,10 +78,7 @@ export async function CreateVehicle(
     );
   }
 
-  if (!entity) return;
-
   return new OxVehicle(
-    entity,
     invokingScript,
     data.plate,
     data.model,
@@ -91,6 +87,7 @@ export async function CreateVehicle(
     metadata,
     properties,
     data.id,
+    entity,
     data.vin,
     data.owner,
     data.group
@@ -99,9 +96,9 @@ export async function CreateVehicle(
 
 export async function SpawnVehicle(id: number, coords: Vec3, heading?: number) {
   const invokingScript = GetInvokingResource();
-  const vehicle = await GetStoredVehicleFromId(id);
+  const vehicle = await GetVehicleFromId(id);
 
-  if (!vehicle) return;
+  if (!vehicle || !vehicle.stored) return;
 
   return await CreateVehicle(vehicle, coords, heading, invokingScript);
 }


### PR DESCRIPTION
https://github.com/overextended/ox_core/issues/212

This PR introduces some changes regarding OxVehicle and how we can get an instance of it.
As of right now to get an instance of OxVehicle the vehicle must be spawned in by either using:
- `Ox.CreateVehicle`
- `Ox.SpawnVehicle`

Or by getting an instance of it after being spawned by using the `Ox.GetVehicle*` functions.

However there are instances where we to create a vehicle entry and get the `OxVehicle` from it, E.G. a car shop showing a notification of the plate that was assigned to your new vehicle after purchase, but you don't want to spawn it immediately, this is current **not** possible as if you do not spawn it when creating the entry you will not get an instance of OxVehicle.

Theres also instances where we'd want to get an instance of `OxVehicle` by using its vin, this is so we can call functions such as `setOwner` etc for when a vehicle transfer happens. But this is only possible if the vehicle is being tracked by ox_core. Sure we could run an update query manually, but if we can do everything with classes, why not let ox_core handle it.

This change will allow OxVehicle class to be created without the need of an Entity by making it an nullable field and an internal ID taking its place for the member lookups.

This will add support for being able to use `Ox.GetVehicleFromVin` which will first get the vehicle if its already being tracked, otherwise it will query the database for the vehicle and create & cache the OxVehicle created from it.

Changes:
- [Fix] `/dv` command not using 2 as default radius when not in vehicle.
- [Fix] `Ox.CreateVehicle` Not creating an entry in the DB when coords are not provided.
- [Fix] `Ox.CreateVehicle` Not returning an instance of OxVehicle when coords not provided.
- [Fix] `vehicle.respawn` Not working providing coords & rotation.
- [Change] Use `internalId` for OxVehicle tracking
- [Change] `OxVehicle.entity` is now nullable and not required.
- [Change] Add `stored` to the output of `VehicleRow`

If this PR is okay to be merged in I will work on updating the docs to reflect the changes.