### PR TITLE
fix(server/accounts): return 'insufficient_balance' if not enough balance

### DIFF
--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -58,7 +58,7 @@ export async function UpdateBalance(
   if (!success)
     return {
       success: false,
-      message: 'no_balance',
+      message: 'insufficient_balance',
     };
 
   const didUpdate =

--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -55,9 +55,13 @@ export async function UpdateBalance(
   const success = addAction
     ? await conn.update(addBalance, [amount, id])
     : await conn.update(overdraw ? removeBalance : safeRemoveBalance, [amount, id, amount]);
+  if (!success)
+    return {
+      success: false,
+      message: 'no_balance',
+    };
 
   const didUpdate =
-    success &&
     (await conn.update(addTransaction, [
       actorId || null,
       addAction ? null : id,


### PR DESCRIPTION
Return `no_balance` instead of `something_went_wrong` in `UpdateBalance` when the account doesn’t have enough balance.