### PR TITLE
feat(server/player): GetLicense and GetLicenses exports

### DIFF
--- a/lib/server/index.ts
+++ b/lib/server/index.ts
@@ -1,7 +1,7 @@
 import type { OxVehicle } from 'server/vehicle/class';
 import type { PayAccountInvoice, DeleteAccountInvoice } from 'server/accounts';
 import type { OxPlayer } from 'server/player/class';
-import type { GetCharIdFromStateId } from 'server/player/db';
+import type { GetCharIdFromStateId, GetLicense, GetLicenses } from 'server/player/db';
 import type { CreateGroup, DeleteGroup, GetGroupsByType, RemoveGroupPermission, SetGroupPermission } from 'server/groups';
 import { Ox as OxCore, OxCommon } from 'lib';
 
@@ -18,6 +18,8 @@ interface OxServer extends OxCommon {
   GetGroupsByType: typeof GetGroupsByType;
   CreateGroup: typeof CreateGroup;
   DeleteGroup: typeof DeleteGroup;
+  GetLicenses: typeof GetLicenses;
+  GetLicense: typeof GetLicense;
 }
 
 export const Ox = OxCore as OxServer;

--- a/server/player/db.ts
+++ b/server/player/db.ts
@@ -81,7 +81,7 @@ export function GetLicense(name: string) {
 }
 
 export function GetCharacterLicenses(charId: number) {
-  return db.query<{ name: string; data: CharacterLicense }>('SELECT name, data FROM character_licenses WHERE charid = ?', [
+  return db.query<{ name: string; data: CharacterLicense }>('SELECT name, data FROM character_licenses WHERE charId = ?', [
     charId,
   ]);
 }

--- a/server/player/db.ts
+++ b/server/player/db.ts
@@ -1,4 +1,4 @@
-import type { Character, Dict, OxStatus, CharacterLicense } from 'types';
+import type { Character, Dict, OxStatus, CharacterLicense, OxLicense } from 'types';
 import { CHARACTER_SLOTS } from '../../common/config';
 import { db } from '../db';
 
@@ -73,7 +73,11 @@ export function GetStatuses() {
 }
 
 export function GetLicenses() {
-  return db.query<{ name?: string; label: string }>('SELECT name, label FROM ox_licenses');
+  return db.query<Dict<OxLicense>>('SELECT name, label FROM ox_licenses');
+}
+
+export function GetLicense(name: string) {
+  return db.row<OxLicense>('SELECT name, label FROM ox_licenses WHERE name = ?', [name]);
 }
 
 export function GetCharacterLicenses(charId: number) {

--- a/server/player/license.ts
+++ b/server/player/license.ts
@@ -1,8 +1,8 @@
 import { addCommand } from '@overextended/ox_lib/server';
-import { GetLicenses } from './db';
-import type { Dict } from 'types';
+import type { Dict, OxLicense } from 'types';
+import { GetLicense, GetLicenses } from './db';
 
-export const Licenses: Dict<{ label: string }> = {};
+export const Licenses: Dict<OxLicense> = {};
 
 async function LoadLicenses() {
   const rows = await GetLicenses();
@@ -25,3 +25,6 @@ addCommand('reloadlicenses', LoadLicenses, {
   help: 'Reload licenses from the database.',
   restricted: 'group.admin',
 });
+
+exports('GetLicenses', GetLicenses);
+exports('GetLicense', GetLicense);

--- a/types/index.ts
+++ b/types/index.ts
@@ -104,6 +104,11 @@ export interface VehicleData extends VehicleStats {
   weapons?: true;
 }
 
+export interface OxLicense {
+  name?: string;
+  label?: string;
+}
+
 export interface OxStatus {
   name: string;
   default: number;


### PR DESCRIPTION
Implements a way using the core functions to get license data instead of having to write own queries.
```lua
RegisterCommand('test', function(source)
    local player = Ox.GetPlayer(source)
    lib.print.info(Ox.GetLicenses(), Ox.GetLicense('driver'), player.getLicense(), player.getLicense('driver'))
end)
```
I will pr docs when accepted for merge.