### PR TITLE
fix(server/account): missing transaction reason causing db errors

### DIFF
--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -60,6 +60,8 @@ export async function UpdateBalance(
       success: false,
       message: 'insufficient_balance',
     };
+  
+  !message && (message = locales(action === 'add' ? 'deposit' : 'withdraw'));
 
   const didUpdate =
     (await conn.update(addTransaction, [


### PR DESCRIPTION
Documentation states that the transaction (remove / add / transfer) message parameter is optional. However, this isn't always going to work, since, on transaction, a new row is added into `accounts_transactions`. If the message isn't specified in an `OxAccount` function, let's say, `removeBalance` it's going to spit out an error specifying so, because the SQL does not allow the said column to be NULL.

Hence, if the documentation is indeed correct and it's not required to specify a message (reason), then the proposed changes should apply the default withdrawal / deposit locales if `message` does not exist.