### PR TITLE
fix: revert client build target to ES2021

### DIFF
--- a/build.js
+++ b/build.js
@@ -40,7 +40,7 @@ createBuilder(
       name: 'client',
       options: {
         platform: 'browser',
-        target: ['es2023'],
+        target: ['es2021'],
         format: 'iife',
         entryPoints: [`./client/index.ts`],
       },


### PR DESCRIPTION
Building to ES2023 does not allow the client to join the server. After testing, reverting the target back to ES2021 has successfully fixed it.