### PR TITLE
fix(death): omit hospital blips if death system not in use

### DIFF
--- a/client/death.ts
+++ b/client/death.ts
@@ -7,7 +7,7 @@ import { LoadDataFile } from '../common';
 const hospitals: Vector4[] = LoadDataFile('hospitals').map((vec: number[]) => {
   const hospital = Vector4.fromArray(vec);
 
-  if (HOSPITAL_BLIPS) {
+  if (HOSPITAL_BLIPS && DEATH_SYSTEM) {
     const blip = AddBlipForCoord(hospital.x, hospital.y, hospital.z);
 
     SetBlipSprite(blip, 61);


### PR DESCRIPTION
Hospital blips are currently enabled even with `ox:deathSystem` set to 0 and replicated.