### PR TITLE
feat(client/spawn): add option for external character select

### DIFF
--- a/client/config.ts
+++ b/client/config.ts
@@ -4,3 +4,4 @@ export const DEATH_SYSTEM = GetConvarInt('ox:deathSystem', 1) === 1;
 export const CHARACTER_SELECT = GetConvarInt('ox:characterSelect', 1) === 1;
 export const SPAWN_LOCATION = JSON.parse(GetConvar('ox:spawnLocation', '[-258.211, -293.077, 21.6132, 206.0]'));
 export const HOSPITAL_BLIPS = GetConvarInt('ox:hospitalBlips', 1) === 1;
+export const EXTERNAL_CHARACTER_SELECT = GetConvarInt('ox:externalCharacterSelect', 0) === 1;

--- a/client/spawn.ts
+++ b/client/spawn.ts
@@ -2,7 +2,7 @@ import { sleep, waitFor } from '@overextended/ox_lib';
 import { cache, inputDialog } from '@overextended/ox_lib/client';
 import { OxPlayer } from './player';
 import { netEvent } from 'utils';
-import { CHARACTER_SELECT, SPAWN_LOCATION } from 'config';
+import { CHARACTER_SELECT, EXTERNAL_CHARACTER_SELECT, SPAWN_LOCATION } from 'config';
 import locale from '../common/locales';
 import type { Character, NewCharacter } from 'types';
 
@@ -75,6 +75,8 @@ netEvent('ox:startCharacterSelect', async (_userId: number, characters: Characte
   if (character) {
     return emitNet('ox:setActiveCharacter', character.charId);
   }
+
+  if (!EXTERNAL_CHARACTER_SELECT) return;
 
   const input = await inputDialog(
     locale('create_character'),


### PR DESCRIPTION
Added to allow custom character creation UIs and run additional logic before showing a menu.