### PR TITLE
fix(server/player): increase activeCount back when changing grade

### DIFF
--- a/server/player/class.ts
+++ b/server/player/class.ts
@@ -421,6 +421,8 @@ export class OxPlayer extends ClassInterface {
 
     this.#groups[group.name] = grade;
     GlobalState[`${group.name}:count`] += 1;
+
+    if (group.name === this.get('activeGroup')) GlobalState[`${group.name}:activeCount`] += 1;
   }
 
   /** Removes the active character from the group and sets permissions. */


### PR DESCRIPTION
This PR fixes an issue where `group:activeCount` wouldn't increase back after changing grade while keeping the same group.

Issue reproduction steps:
1. `/setgroup me police 1`
2. set `police` as active group
3. check `police:activeCount` (1)
4. `/setgroup me police 2`
5. check `police:activeCount` (0)