### PR TITLE
Chore: add GetVehicleFromEntity to lib

### DIFF
--- a/lib/server/vehicle.lua
+++ b/lib/server/vehicle.lua
@@ -57,6 +57,10 @@ function Ox.GetVehicle(entityId)
     return CreateVehicleInstance(exports.ox_core:GetVehicle(entityId))
 end
 
+function Ox.GetVehicleFromEntity(entityId)
+    return CreateVehicleInstance(exports.ox_core:GetVehicleFromEntity(entityId))
+end
+
 function Ox.GetVehicleFromNetId(netId)
     return CreateVehicleInstance(exports.ox_core:GetVehicleFromNetId(netId))
 end


### PR DESCRIPTION
Using Ox.GetVehicleFromEntity in a callback with a wait would randomly crash my server thought it was Node 22 related but once I added it to the lib it worked 🤷 