### PR TITLE
fix(server/groups): add restriction to setgroup command

### DIFF
--- a/server/groups/index.ts
+++ b/server/groups/index.ts
@@ -166,6 +166,7 @@ addCommand<{ target: string; group: string; grade?: number }>(
   },
   {
     help: `Update a player's grade for a group.`,
+    restricted: 'group.admin',
     params: [
       { name: 'target', paramType: 'playerId' },
       { name: 'group', paramType: 'string' },


### PR DESCRIPTION
Hi there,

I noticed that the setgroup command does not appear to have any permission checks, such as restricted: group.admin or something similar.

If I'm understanding the current implementation correctly, this would mean that any user can execute the command and assign themselves to any group, including admin-level groups. This could potentially lead to serious security and access control issues.

Could you confirm whether this is intended behavior or an oversight?
In this PR, I’ve added a restriction requiring the group.admin permission.

Thanks in advance!