### PR TITLE
fix(setStored): remove vin from OxVehicle list

### DIFF
--- a/server/vehicle/class.ts
+++ b/server/vehicle/class.ts
@@ -230,7 +230,7 @@ export class OxVehicle extends ClassInterface {
   setStored(value: string | null, despawn?: boolean) {
     this.#stored = value;
 
-    if (despawn) return this.despawn(true);
+    if (despawn) return this.remove();
 
     SetVehicleColumn(this.id, 'stored', value);
   }


### PR DESCRIPTION
Basically this.despawn does not trigger `OxVehicle.remove(this.vin)` and if we delete an entity without removing it from OxVehicle it tries to respawn it using the old entity and it breaks.

This just changes this,despawn to this.remove which does the same but also calls `OxVehicle.remove(this.vin)` not sure if it should of been just called directly in despawn, not sure as I couldnt see any use cases for that but I just went the "safe route"