### PR TITLE
Fix/accounts transaction integrity

### DIFF
--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -53,14 +53,21 @@ export async function UpdateBalance(
     };
 
   const addAction = action === 'add';
+
+  await conn.beginTransaction();
+
   const success = addAction
     ? await conn.update(addBalance, [amount, accountId])
     : await conn.update(overdraw ? removeBalance : safeRemoveBalance, [amount, accountId, amount]);
-  if (!success)
+
+  if (!success) {
+    await conn.rollback();
+
     return {
       success: false,
       message: 'insufficient_balance',
     };
+  }
 
   !message && (message = locales(action === 'add' ? 'deposit' : 'withdraw'));
 
@@ -76,11 +83,16 @@ export async function UpdateBalance(
       addAction ? balance + amount : null,
     ])) === 1;
 
-  if (!didUpdate)
+  if (!didUpdate) {
+    await conn.rollback();
+
     return {
       success: false,
       message: 'something_went_wrong',
     };
+  }
+
+  await conn.commit();
 
   emit('ox:updatedBalance', { accountId, amount, action });
 

--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -267,6 +267,8 @@ export async function DepositMoney(
     balance + amount,
   ]);
 
+  await conn.commit();
+
   emit('ox:depositedMoney', { playerId, accountId, amount });
 
   return {
@@ -322,6 +324,8 @@ export async function WithdrawMoney(
     balance - amount,
     null,
   ]);
+
+  await conn.commit();
 
   emit('ox:withdrewMoney', { playerId, accountId, amount });
 

--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -144,6 +144,8 @@ export async function PerformTransaction(
         toBalance + amount,
       ]);
 
+      await conn.commit();
+
       emit('ox:transferredMoney', { fromId, toId, amount });
 
       return { success: true };

--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -99,6 +99,43 @@ export async function UpdateBalance(
   return { success: true };
 }
 
+/** Moves funds between two accounts on an existing transaction, without committing. */
+async function ApplyTransfer(
+  conn: Connection,
+  fromId: number,
+  toId: number,
+  amount: number,
+  overdraw: boolean,
+  fromBalance: number,
+  toBalance: number,
+  message?: string,
+  note?: string,
+  actorId?: number,
+) {
+  const query = overdraw ? removeBalance : safeRemoveBalance;
+  const values = [amount, fromId];
+
+  if (!overdraw) values.push(amount);
+
+  const removedBalance = await conn.update(query, values);
+  const addedBalance = removedBalance && (await conn.update(addBalance, [amount, toId]));
+
+  if (!addedBalance) return false;
+
+  await conn.execute(addTransaction, [
+    actorId,
+    fromId,
+    toId,
+    amount,
+    message ?? locales('transfer'),
+    note,
+    fromBalance - amount,
+    toBalance + amount,
+  ]);
+
+  return true;
+}
+
 export async function PerformTransaction(
   fromId: number,
   toId: number,
@@ -124,26 +161,7 @@ export async function PerformTransaction(
   await conn.beginTransaction();
 
   try {
-    const query = overdraw ? removeBalance : safeRemoveBalance;
-    const values = [amount, fromId];
-
-    if (!overdraw) values.push(amount);
-
-    const removedBalance = await conn.update(query, values);
-    const addedBalance = removedBalance && (await conn.update(addBalance, [amount, toId]));
-
-    if (addedBalance) {
-      await conn.execute(addTransaction, [
-        actorId,
-        fromId,
-        toId,
-        amount,
-        message ?? locales('transfer'),
-        note,
-        fromBalance - amount,
-        toBalance + amount,
-      ]);
-
+    if (await ApplyTransfer(conn, fromId, toId, amount, overdraw, fromBalance, toBalance, message, note, actorId)) {
       await conn.commit();
 
       emit('ox:transferredMoney', { fromId, toId, amount });
@@ -377,37 +395,59 @@ export async function UpdateInvoice(
 
   if (!hasPermission) return { success: false, message: 'no_permission' };
 
-  const transfer = await PerformTransaction(
-    invoice.toAccount,
-    invoice.fromAccount,
-    invoice.amount,
-    false,
-    locales('invoice_payment'),
-    undefined,
-    charId,
-  );
+  await using conn = await GetConnection();
 
-  if (!transfer.success) return { success: false, message: transfer.message ?? 'no_balance' };
+  const fromBalance = await conn.scalar<number>(getBalance, [invoice.toAccount]);
+  const toBalance = await conn.scalar<number>(getBalance, [invoice.fromAccount]);
 
-  const invoiceUpdated = await db.update('UPDATE `accounts_invoices` SET `payerId` = ?, `paidAt` = ? WHERE `id` = ?', [
-    player.charId,
-    new Date(),
-    invoiceId,
-  ]);
+  if (fromBalance === null || toBalance === null) return { success: false, message: 'no_balance' };
 
-  if (!invoiceUpdated)
-    return {
-      success: false,
-      message: 'invoice_not_updated',
-    };
+  await conn.beginTransaction();
+
+  try {
+    const transferred = await ApplyTransfer(
+      conn,
+      invoice.toAccount,
+      invoice.fromAccount,
+      invoice.amount,
+      false,
+      fromBalance,
+      toBalance,
+      locales('invoice_payment'),
+      undefined,
+      charId,
+    );
+
+    if (!transferred) {
+      await conn.rollback();
+      return { success: false, message: 'no_balance' };
+    }
+
+    const invoiceUpdated = await conn.update(
+      'UPDATE `accounts_invoices` SET `payerId` = ?, `paidAt` = ? WHERE `id` = ?',
+      [player.charId, new Date(), invoiceId],
+    );
+
+    if (!invoiceUpdated) {
+      await conn.rollback();
+      return { success: false, message: 'invoice_not_updated' };
+    }
+
+    await conn.commit();
+  } catch (e) {
+    console.error(`Failed to pay invoice ${invoiceId}`);
+    console.log(e);
+
+    await conn.rollback();
+    return { success: false, message: 'something_went_wrong' };
+  }
 
   invoice.payerId = charId;
 
+  emit('ox:transferredMoney', { fromId: invoice.toAccount, toId: invoice.fromAccount, amount: invoice.amount });
   emit('ox:invoicePaid', invoice);
 
-  return {
-    success: true,
-  };
+  return { success: true };
 }
 
 export async function CreateInvoice({

--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -43,7 +43,7 @@ export async function UpdateBalance(
 
   if (amount <= 0) return { success: false, message: 'invalid_amount' };
 
-  using conn = await GetConnection();
+  await using conn = await GetConnection();
   const balance = await conn.scalar<number>(getBalance, [accountId]);
 
   if (balance === null)
@@ -114,7 +114,7 @@ export async function PerformTransaction(
 
   if (amount <= 0) return { success: false, message: 'invalid_amount' };
 
-  using conn = await GetConnection();
+  await using conn = await GetConnection();
 
   const fromBalance = await conn.scalar<number>(getBalance, [fromId]);
   const toBalance = await conn.scalar<number>(getBalance, [toId]);
@@ -235,7 +235,7 @@ export async function DepositMoney(
 
   if (amount > money) return { success: false, message: 'insufficient_funds' };
 
-  using conn = await GetConnection();
+  await using conn = await GetConnection();
   const balance = await conn.scalar<number>(getBalance, [accountId]);
 
   if (balance === null) return { success: false, message: 'no_balance' };
@@ -293,7 +293,7 @@ export async function WithdrawMoney(
 
   if (!player?.charId) return { success: false, message: 'no_charId' };
 
-  using conn = await GetConnection();
+  await using conn = await GetConnection();
   const role = await conn.scalar<OxAccountRole>(selectAccountRole, [accountId, player.charId]);
 
   if (!(await CanPerformAction(player, accountId, role, 'withdraw'))) return { success: false, message: 'no_access' };

--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -373,29 +373,17 @@ export async function UpdateInvoice(
 
   if (!hasPermission) return { success: false, message: 'no_permission' };
 
-  const updateReceiver = await UpdateBalance(
+  const transfer = await PerformTransaction(
     invoice.toAccount,
-    invoice.amount,
-    'remove',
-    false,
-    locales('invoice_payment'),
-    undefined,
-    charId,
-  );
-
-  if (!updateReceiver.success) return { success: false, message: 'no_balance' };
-
-  const updateSender = await UpdateBalance(
     invoice.fromAccount,
     invoice.amount,
-    'add',
     false,
     locales('invoice_payment'),
     undefined,
     charId,
   );
 
-  if (!updateSender.success) return { success: false, message: 'no_balance' };
+  if (!transfer.success) return { success: false, message: transfer.message ?? 'no_balance' };
 
   const invoiceUpdated = await db.update('UPDATE `accounts_invoices` SET `payerId` = ?, `paidAt` = ? WHERE `id` = ?', [
     player.charId,

--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -155,7 +155,7 @@ export async function PerformTransaction(
     console.log(e);
   }
 
-  conn.rollback();
+  await conn.rollback();
 
   return { success: false, message: 'something_went_wrong' };
 }
@@ -249,7 +249,7 @@ export async function DepositMoney(
   const affectedRows = await conn.update(addBalance, [amount, accountId]);
 
   if (!affectedRows || !exports.ox_inventory.RemoveItem(playerId, 'money', amount)) {
-    conn.rollback();
+    await conn.rollback();
     return {
       success: false,
       message: 'something_went_wrong',
@@ -305,7 +305,7 @@ export async function WithdrawMoney(
   const affectedRows = await conn.update(safeRemoveBalance, [amount, accountId, amount]);
 
   if (!affectedRows || !exports.ox_inventory.AddItem(playerId, 'money', amount)) {
-    conn.rollback();
+    await conn.rollback();
     return {
       success: false,
       message: 'something_went_wrong',

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -4,6 +4,7 @@ import type { Dict } from 'types';
 import type { PoolConnection, QueryOptions } from 'mariadb';
 
 (Symbol as any).dispose ??= Symbol('Symbol.dispose');
+(Symbol as any).asyncDispose ??= Symbol('Symbol.asyncDispose');
 
 export interface MySqlRow<T = string | number | boolean | Dict<any> | undefined> {
   [column: string]: T;
@@ -72,8 +73,13 @@ export class Connection {
     return this.connection.commit();
   }
 
+  async [Symbol.asyncDispose]() {
+    if (this.transaction) await this.rollback();
+    await this.connection.release();
+  }
+
   [Symbol.dispose]() {
-    if (this.transaction) this.commit();
+    if (this.transaction) this.rollback();
     this.connection.release();
   }
 }

--- a/server/groups/db.ts
+++ b/server/groups/db.ts
@@ -20,7 +20,7 @@ export function SelectGroups() {
 }
 
 export async function InsertGroup({ name, label, type, colour, hasAccount, grades, accountRoles }: DbGroup) {
-  using conn = await GetConnection();
+  await using conn = await GetConnection();
   await conn.beginTransaction();
 
   const insertedGroup = await conn.update(

--- a/server/groups/db.ts
+++ b/server/groups/db.ts
@@ -35,6 +35,8 @@ export async function InsertGroup({ name, label, type, colour, hasAccount, grade
     grades.map((gradeLabel, index) => [name, index + 1, gradeLabel, accountRoles[index + 1]]),
   )) as UpsertResult[];
 
+  await conn.commit();
+
   return insertedGrades.reduce((acc, curr) => acc + curr.affectedRows, 0) > 0;
 }
 


### PR DESCRIPTION
# Description

The account money functions had several ways to lose or duplicate money when a query failed partway through, all rooted in how transactions were opened, committed, and cleaned up. This fixes them across `server/accounts/db.ts`, `server/groups/db.ts`, and `server/db/index.ts`.

## What was wrong

**Balance changes and their ledger rows weren't atomic.** `UpdateBalance` updated the balance and inserted the ledger row as two separate autocommitted statements. If the ledger insert failed, the balance had already changed and committed while the function returned failure.

**Invoice payments moved money in separate steps.** `UpdateInvoice` debited one account and credited the other independently, then marked the invoice paid in a third statement. A failure between any of them lost money or left a paid invoice unflagged.

**Transactions committed and rolled back without awaiting.** `PerformTransaction`, `DepositMoney`, and `WithdrawMoney` leaned on connection disposal to commit, and disposal fired the commit without awaiting it before releasing the connection back to the pool. The rollbacks had the same race.

**Disposal committed whatever was still open.** If a function threw mid-transaction, the connection wrapper committed the half-finished transaction on disposal instead of rolling it back.

## What changed

- `UpdateBalance` wraps its balance update and ledger insert in one transaction.
- `DepositMoney`, `WithdrawMoney`, `PerformTransaction`, and `InsertGroup` commit explicitly instead of relying on disposal.
- Every rollback is awaited.
- Connection disposal now rolls back any still-open transaction and awaits both the rollback and the release. Functions that open a transaction use `await using` so this runs as async cleanup (`server/db/index.ts`).
- `UpdateInvoice` and `PerformTransaction` share one `ApplyTransfer` helper, so the invoice's money move and its paid flag commit together in a single transaction:

```ts
await conn.beginTransaction();

try {
  const transferred = await ApplyTransfer(conn, invoice.toAccount, invoice.fromAccount, invoice.amount, false, fromBalance, toBalance, locales('invoice_payment'), undefined, charId);
  if (!transferred) { await conn.rollback(); return { success: false, message: 'no_balance' }; }

  const invoiceUpdated = await conn.update('UPDATE `accounts_invoices` SET `payerId` = ?, `paidAt` = ? WHERE `id` = ?', [player.charId, new Date(), invoiceId]);
  if (!invoiceUpdated) { await conn.rollback(); return { success: false, message: 'invoice_not_updated' }; }

  await conn.commit();
} catch (e) {
  await conn.rollback();
  return { success: false, message: 'something_went_wrong' };
}
```

The invoice ledger is now a single transfer row and one `ox:transferredMoney` event, same as a normal transfer. `ox:invoicePaid` still fires.
