### PR TITLE
feat(server/vehicle): only use entityRemoved event if not using sv_protectServerEntities

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -4,4 +4,6 @@ export * from '../common/config';
 
 export const CREATE_DEFAULT_ACCOUNT = GetConvarInt('ox:createDefaultAccount', 1) === 1;
 
+export const PROTECT_SERVER_ENTITIES = GetConvarInt('sv_protectServerEntities', 0) === 1;
+
 if (DEBUG) SetConvar('ox:callbackTimeout', '1200000');

--- a/server/config.ts
+++ b/server/config.ts
@@ -4,6 +4,6 @@ export * from '../common/config';
 
 export const CREATE_DEFAULT_ACCOUNT = GetConvarInt('ox:createDefaultAccount', 1) === 1;
 
-export const PROTECT_SERVER_ENTITIES = GetConvarInt('sv_protectServerEntities', 0) === 1;
+export const PROTECT_SERVER_ENTITIES = GetConvarBool('sv_protectServerEntities', false);
 
 if (DEBUG) SetConvar('ox:callbackTimeout', '1200000');

--- a/server/vehicle/events.ts
+++ b/server/vehicle/events.ts
@@ -1,5 +1,12 @@
 import { OxVehicle } from './class';
+import { PROTECT_SERVER_ENTITIES } from '../config';
 
 on('onResourceStop', (resource: string) => OxVehicle.saveAll(resource));
 
-on('entityRemoved', (entityId: number) => OxVehicle.getFromEntity(entityId)?.respawn());
+if (!PROTECT_SERVER_ENTITIES) {
+  console.warn(
+    "^3sv_protectServerEntities is not enabled - falling back to 'entityRemoved' event to respawn vehicles deleted by clients, which may degrade performance. Enable sv_protectServerEntities to avoid this.^0",
+  );
+
+  on('entityRemoved', (entityId: number) => OxVehicle.getFromEntity(entityId)?.respawn());
+}


### PR DESCRIPTION
`entityRemoved` consumes quite a lot of resources because it includes **everything** clients delete including population.

Using `sv_protectServerEntities` makes this event useless and serves no purpose so we disable it to optimize server performance with ox_core even further.