### PR TITLE
fix(accounts): reverse the money item when a deposit or withdrawal fails

### DIFF
--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -266,7 +266,7 @@ export async function DepositMoney(
 
   const affectedRows = await conn.update(addBalance, [amount, accountId]);
 
-  if (!affectedRows || !exports.ox_inventory.RemoveItem(playerId, 'money', amount)) {
+  if (!affectedRows) {
     await conn.rollback();
     return {
       success: false,
@@ -274,23 +274,26 @@ export async function DepositMoney(
     };
   }
 
-  try {
-    await conn.execute(addTransaction, [
-      player.charId,
-      null,
-      accountId,
-      amount,
-      message ?? locales('deposit'),
-      note,
-      null,
-      balance + amount,
-    ]);
+  await conn.execute(addTransaction, [
+    player.charId,
+    null,
+    accountId,
+    amount,
+    message ?? locales('deposit'),
+    note,
+    null,
+    balance + amount,
+  ]);
 
-    await conn.commit();
-  } catch (e) {
-    exports.ox_inventory.AddItem(playerId, 'money', amount);
-    return { success: false, message: 'something_went_wrong' };
+  if (!exports.ox_inventory.RemoveItem(playerId, 'money', amount)) {
+    await conn.rollback();
+    return {
+      success: false,
+      message: 'something_went_wrong',
+    };
   }
+
+  await conn.commit();
 
   emit('ox:depositedMoney', { playerId, accountId, amount });
 
@@ -329,7 +332,7 @@ export async function WithdrawMoney(
 
   const affectedRows = await conn.update(safeRemoveBalance, [amount, accountId, amount]);
 
-  if (!affectedRows || !exports.ox_inventory.AddItem(playerId, 'money', amount)) {
+  if (!affectedRows) {
     await conn.rollback();
     return {
       success: false,
@@ -337,23 +340,26 @@ export async function WithdrawMoney(
     };
   }
 
-  try {
-    await conn.execute(addTransaction, [
-      player.charId,
-      accountId,
-      null,
-      amount,
-      message ?? locales('withdraw'),
-      note,
-      balance - amount,
-      null,
-    ]);
+  await conn.execute(addTransaction, [
+    player.charId,
+    accountId,
+    null,
+    amount,
+    message ?? locales('withdraw'),
+    note,
+    balance - amount,
+    null,
+  ]);
 
-    await conn.commit();
-  } catch (e) {
-    exports.ox_inventory.RemoveItem(playerId, 'money', amount);
-    return { success: false, message: 'something_went_wrong' };
+  if (!exports.ox_inventory.AddItem(playerId, 'money', amount)) {
+    await conn.rollback();
+    return {
+      success: false,
+      message: 'something_went_wrong',
+    };
   }
+
+  await conn.commit();
 
   emit('ox:withdrewMoney', { playerId, accountId, amount });
 

--- a/server/accounts/db.ts
+++ b/server/accounts/db.ts
@@ -274,18 +274,23 @@ export async function DepositMoney(
     };
   }
 
-  await conn.execute(addTransaction, [
-    player.charId,
-    null,
-    accountId,
-    amount,
-    message ?? locales('deposit'),
-    note,
-    null,
-    balance + amount,
-  ]);
+  try {
+    await conn.execute(addTransaction, [
+      player.charId,
+      null,
+      accountId,
+      amount,
+      message ?? locales('deposit'),
+      note,
+      null,
+      balance + amount,
+    ]);
 
-  await conn.commit();
+    await conn.commit();
+  } catch (e) {
+    exports.ox_inventory.AddItem(playerId, 'money', amount);
+    return { success: false, message: 'something_went_wrong' };
+  }
 
   emit('ox:depositedMoney', { playerId, accountId, amount });
 
@@ -332,18 +337,23 @@ export async function WithdrawMoney(
     };
   }
 
-  await conn.execute(addTransaction, [
-    player.charId,
-    accountId,
-    null,
-    amount,
-    message ?? locales('withdraw'),
-    note,
-    balance - amount,
-    null,
-  ]);
+  try {
+    await conn.execute(addTransaction, [
+      player.charId,
+      accountId,
+      null,
+      amount,
+      message ?? locales('withdraw'),
+      note,
+      balance - amount,
+      null,
+    ]);
 
-  await conn.commit();
+    await conn.commit();
+  } catch (e) {
+    exports.ox_inventory.RemoveItem(playerId, 'money', amount);
+    return { success: false, message: 'something_went_wrong' };
+  }
 
   emit('ox:withdrewMoney', { playerId, accountId, amount });
 


### PR DESCRIPTION
# Description

Follow-up to #248.

That PR made connection disposal roll back an uncommitted transaction instead of committing it. Correct for the database-only paths, but `DepositMoney` and `WithdrawMoney` move a `money` item through ox_inventory in the middle of the transaction, and ox_inventory isn't part of it.

So if the ledger insert throws after the item has already moved (a deadlock, lock-wait timeout, etc.), disposal rolls the balance back while the item stays out. A withdrawal then duplicates money (account refunded, player keeps the cash); a deposit loses it.

## Fix

Wrap the ledger insert and commit in a try/catch and reverse the item if they throw. Disposal still rolls back the balance, so the catch only undoes the item:

```ts
try {
  await conn.execute(addTransaction, [...]);
  await conn.commit();
} catch (e) {
  exports.ox_inventory.RemoveItem(playerId, 'money', amount); // AddItem for deposits
  return { success: false, message: 'something_went_wrong' };
}
```

Account balance and inventory stay consistent on failure.
