### PR TITLE
fix(server/accounts): return cached account instance in OxAccount.get

### DIFF
--- a/server/accounts/class.ts
+++ b/server/accounts/class.ts
@@ -38,7 +38,9 @@ export class OxAccount extends ClassInterface {
   protected static members: Dict<OxAccount> = {};
 
   static async get(accountId: number) {
-    if (accountId in this.members) this.members[accountId];
+    const account = this.members[accountId];
+
+    if (account) return account;
 
     const validAccount = await SelectAccount(accountId);
 


### PR DESCRIPTION
## Problem

`OxAccount.get` never returns its cached instance:

```ts
static async get(accountId: number) {
  if (accountId in this.members) this.members[accountId];

  const validAccount = await SelectAccount(accountId);
  ...
  return new OxAccount(accountId);
}
```

`this.members[accountId]` is an expression statement, so the looked-up value is discarded. Every call falls through to `SelectAccount` and constructs a new `OxAccount`, which makes the cache write-only — the eviction interval in `server/accounts/index.ts` has nothing to evict that was ever read.

Because `ClassInterface.add` returns early when the id is already registered, the registry keeps the very first instance while every later caller receives a throwaway one. The extra instances are not leaked, but each lookup pays for a redundant `SELECT`.

## Fix

Return the cached instance when one exists.

## Behaviour

Identical, minus the redundant query:

- `DeleteAccount` only sets `type = 'inactive'` and never deletes the row, and `SelectAccount` does not filter on `type`. So a cached `accountId` always still resolves in the database — the `SELECT` could never turn a cache hit into the `No account exists` error.
- `OxAccount` holds no mutable state beyond `accountId`, so a cached instance is equivalent to a freshly constructed one.

## Impact

Minor. The wasted query is a primary-key lookup, so this is a correctness/hygiene fix rather than a performance emergency. Note that `GetCharacterAccount` and `GetGroupAccount` still run `SelectDefaultAccountId` beforehand, so only the second query is avoided on those paths.
