### PR TITLE
fix(server/player)!: derive statuses on the server

### DIFF
--- a/client/player/status.ts
+++ b/client/player/status.ts
@@ -13,7 +13,6 @@ function UpdateStatuses() {
   }
 
   emit('ox:statusTick', OxPlayer.getStatuses());
-  emitNet('ox:updateStatuses', OxPlayer.getStatuses());
 }
 
 on('ox:playerLoaded', () => {

--- a/server/player/class.ts
+++ b/server/player/class.ts
@@ -14,7 +14,7 @@ import {
 import { getRandomChar, getRandomInt } from '@overextended/ox_lib';
 import { GetGroup, GetGroupsByType } from 'groups';
 import { GeneratePhoneNumber } from 'bridge/npwd';
-import { Statuses } from './status';
+import { Statuses, clampStatus } from './status';
 import { addPrincipal, removePrincipal } from '@overextended/ox_lib/server';
 import {
   AddCharacterGroup,
@@ -41,6 +41,7 @@ export class OxPlayer extends ClassInterface {
   #characters: Character[];
   #metadata: Dict<any>;
   #statuses: Dict<number>;
+  #statusesTickedAt: number;
   #groups: Dict<number>;
   #licenses: Dict<CharacterLicense>;
 
@@ -151,6 +152,7 @@ export class OxPlayer extends ClassInterface {
     this.#characters = [];
     this.#metadata = {};
     this.#statuses = {};
+    this.#statusesTickedAt = GetGameTimer();
     this.#groups = {};
     this.#licenses = {};
   }
@@ -314,12 +316,29 @@ export class OxPlayer extends ClassInterface {
     return false;
   }
 
+  /** Statuses decay at a fixed rate, so elapsed ticks are applied on access. */
+  get #tickedStatuses() {
+    const ticks = Math.floor((GetGameTimer() - this.#statusesTickedAt) / 1000);
+
+    if (ticks < 1) return this.#statuses;
+
+    this.#statusesTickedAt += ticks * 1000;
+
+    for (const statusName in Statuses) {
+      const value = this.#statuses[statusName];
+
+      if (value !== undefined) this.#statuses[statusName] = clampStatus(value + Statuses[statusName].onTick * ticks);
+    }
+
+    return this.#statuses;
+  }
+
   /** Sets the value of a status. */
   setStatus(statusName: string, value = Statuses[statusName].default) {
     if (Statuses[statusName] === undefined) return;
 
-    const newValue = value < 0 ? 0 : value > 100 ? 100 : Number.parseFloat(value.toPrecision(8));
-    this.#statuses[statusName] = newValue;
+    const newValue = clampStatus(value);
+    this.#tickedStatuses[statusName] = newValue;
 
     this.emit('ox:setPlayerStatus', statusName, newValue, true);
 
@@ -328,35 +347,32 @@ export class OxPlayer extends ClassInterface {
 
   /** Returns the current value of a status. */
   getStatus(statusName: string) {
-    return this.#statuses[statusName];
+    return this.#tickedStatuses[statusName];
   }
 
   /** Returns an object containing all status names and their values. */
   getStatuses() {
-    return this.#statuses;
+    return this.#tickedStatuses;
   }
 
   /** Increases the status's value by the given amount. */
   addStatus(statusName: string, value: number) {
-    if (this.#statuses[statusName] === undefined) return;
-
-    let newValue = this.#statuses[statusName] + value;
-    newValue = newValue < 0 ? 0 : newValue > 100 ? 100 : Number.parseFloat(newValue.toPrecision(8));
-
-    this.#statuses[statusName] = newValue;
-    this.emit('ox:setPlayerStatus', statusName, newValue);
-
-    return true;
+    return this.#adjustStatus(statusName, value);
   }
 
   /** Reduces the status's value by the given amount. */
   removeStatus(statusName: string, value: number) {
-    if (this.#statuses[statusName] === undefined) return;
+    return this.#adjustStatus(statusName, -value);
+  }
 
-    let newValue = this.#statuses[statusName] - value;
-    newValue = newValue < 0 ? 0 : newValue > 100 ? 100 : Number.parseFloat(newValue.toPrecision(8));
+  #adjustStatus(statusName: string, value: number) {
+    const statuses = this.#tickedStatuses;
 
-    this.#statuses[statusName] = newValue;
+    if (statuses[statusName] === undefined) return;
+
+    const newValue = clampStatus(statuses[statusName] + value);
+
+    statuses[statusName] = newValue;
     this.emit('ox:setPlayerStatus', statusName, newValue);
 
     return true;
@@ -420,7 +436,7 @@ export class OxPlayer extends ClassInterface {
       Player(this.source).state.isDead || false,
       GetEntityHealth(this.ped),
       GetPedArmour(this.ped),
-      JSON.stringify(this.#statuses || {}),
+      JSON.stringify(this.#tickedStatuses || {}),
       this.charId,
     ];
   }
@@ -588,6 +604,8 @@ export class OxPlayer extends ClassInterface {
 
     groups.forEach(({ name, grade }) => this.#addGroup(name, grade));
     licenses.forEach(({ name, data }) => (this.#licenses[name] = data));
+
+    this.#statusesTickedAt = GetGameTimer();
 
     for (const name in Statuses) this.setStatus(name, statuses[name]);
 

--- a/server/player/events.ts
+++ b/server/player/events.ts
@@ -2,9 +2,8 @@ import { onClientCallback } from '@overextended/ox_lib/server';
 import { OxPlayer } from './class';
 import { sleep } from '@overextended/ox_lib';
 import { db } from 'db';
-import { Statuses } from './status';
 import { CreateNewAccount } from 'accounts/db';
-import type { Dict, NewCharacter, OxStatus } from 'types';
+import type { Dict, NewCharacter } from 'types';
 import { CREATE_DEFAULT_ACCOUNT } from 'config';
 import './license';
 
@@ -99,21 +98,6 @@ on('ox:createdCharacter', async (playerId: number, userId: number, charId: numbe
   db.execute('INSERT INTO character_inventory (charId) VALUES (?)', [charId]);
 
   if (CREATE_DEFAULT_ACCOUNT) CreateNewAccount(charId, 'Personal', true);
-});
-
-onNet('ox:updateStatuses', async (data: Dict<OxStatus>) => {
-  const player = OxPlayer.get(source);
-
-  if (!player) return;
-
-  for (const name in data) {
-    const status = Statuses[name];
-    const value = data[name];
-
-    if (status && typeof value === 'number') {
-      player.setStatus(name, value);
-    }
-  }
 });
 
 onClientCallback('ox:setActiveGroup', (playerId, groupName: string) => {

--- a/server/player/status.ts
+++ b/server/player/status.ts
@@ -5,6 +5,11 @@ import type { Dict, OxStatus } from 'types';
 
 export const Statuses: Dict<OxStatus> = {};
 
+/** Restricts a status value to the 0-100 range. */
+export function clampStatus(value: number) {
+  return value < 0 ? 0 : value > 100 ? 100 : Number.parseFloat(value.toPrecision(8));
+}
+
 async function LoadStatuses() {
   const rows = await GetStatuses();
 


### PR DESCRIPTION
## Problem

`ox:updateStatuses` applies whatever the client sends:

```ts
onNet('ox:updateStatuses', async (data: Dict<OxStatus>) => {
  ...
  if (status && typeof value === 'number') player.setStatus(name, value);
});
```

The client owns the decay loop and reports the result every second, so the server can't tell a normal tick from an injected one. Anyone able to trigger events can hold hunger and thirst at 100, or keep stress at 0, and ignore survival mechanics entirely.

## Fix

The event is removed and the server derives the values itself. `onTick` is server-side config published through `GlobalState`, so decay is deterministic and there is nothing the client needs to report.

Ticking every player every second would not scale, so elapsed decay is applied when a status is read instead:

```ts
get #tickedStatuses() {
  const ticks = Math.floor((GetGameTimer() - this.#statusesTickedAt) / 1000);
  ...
}
```

`getStatus`, `setStatus`, `#adjustStatus` and `#getSaveData` all read through it. That is O(1) per read and nothing per second, so idle players cost nothing regardless of player count.

The client keeps its tick for the UI (`ox:statusTick`), it just no longer sends the result back.

## Breaking

`ox:updateStatuses` is removed, so any resource listening for it server-side will stop receiving it.

Because the server applies `onTick * ticks` in one step while the client still increments once per second, a displayed value can differ by a rounding step until the next `setStatus` or `addStatus` resyncs the client.
