### PR TITLE
fix(lib/server): use the instance source in player.getState

### DIFF
--- a/lib/server/player.ts
+++ b/lib/server/player.ts
@@ -28,7 +28,7 @@ class PlayerInterface {
   }
 
   getState() {
-    return Player(source).state;
+    return Player(this.source).state;
   }
 
   async getAccount() {


### PR DESCRIPTION
## Problem

`PlayerInterface.getState` reads the global `source` instead of the instance property:

```ts
getState() {
  return Player(source).state;
}
```

Looks like an oversight: the constructor already assigns `this.source`, and every other method uses it. Whenever the instance is used outside of a handler for that same player, `getState` returns another player's state bag, and writes land on the wrong entity.

## Fix

```ts
getState() {
  return Player(this.source).state;
}
```

`lib/server/player.lua` already does this, and `lib/server/vehicle.ts` resolves its state bag from `this.entity`.

## Impact

No API change. Calls that were correct by accident keep working; the others now target the intended player.
